### PR TITLE
fix(youtube): fall back to system ffmpeg when bundled binary fails

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -47,14 +47,53 @@ async function checkAndSetupFfmpeg() {
       if (fs.existsSync(ffprobePath)) {
         ffmpeg.setFfprobePath(ffprobePath);
         console.log('Using ffprobe from ffmpeg directory:', ffprobePath);
+      } else {
+        // Fallback: try system-wide ffprobe from PATH
+        try {
+          const whichProbeCmd = process.platform === 'win32' ? 'where ffprobe' : 'which ffprobe';
+          const probeResult = await execPromise(whichProbeCmd);
+          const systemProbePath = probeResult.stdout.trim().split('\n')[0].trim();
+          ffmpeg.setFfprobePath(systemProbePath);
+          console.log('Using system ffprobe:', systemProbePath);
+        } catch (probeErr) {
+          console.warn('ffprobe not found, some features may be limited');
+        }
       }
     }
     
     return true;
   } catch (error) {
     console.error('Failed to setup bundled ffmpeg:', error);
-    ffmpegAvailable = false;
-    return false;
+    
+    // Fallback: try system-wide ffmpeg from PATH
+    try {
+      const whichCmd = process.platform === 'win32' ? 'where ffmpeg' : 'which ffmpeg';
+      const { stdout } = await execPromise(whichCmd);
+      const systemFfmpegPath = stdout.trim().split('\n')[0].trim();
+      
+      // Verify the system binary works
+      await execPromise(`"${systemFfmpegPath}" -version`);
+      ffmpegPath = systemFfmpegPath;
+      ffmpegAvailable = true;
+      console.log('Using system ffmpeg:', ffmpegPath);
+      
+      // Try to find system ffprobe too
+      try {
+        const whichProbeCmd = process.platform === 'win32' ? 'where ffprobe' : 'which ffprobe';
+        const probeResult = await execPromise(whichProbeCmd);
+        const systemFfprobePath = probeResult.stdout.trim().split('\n')[0].trim();
+        ffmpeg.setFfprobePath(systemFfprobePath);
+        console.log('Using system ffprobe:', systemFfprobePath);
+      } catch (probeErr) {
+        console.warn('System ffprobe not found, some features may be limited');
+      }
+      
+      return true;
+    } catch (systemError) {
+      console.error('System ffmpeg not found either:', systemError.message);
+      ffmpegAvailable = false;
+      return false;
+    }
   }
 }
 

--- a/openspec/changes/archive/2026-05-10-fix-ffmpeg-system-fallback/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-10-fix-ffmpeg-system-fallback/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-10

--- a/openspec/changes/archive/2026-05-10-fix-ffmpeg-system-fallback/design.md
+++ b/openspec/changes/archive/2026-05-10-fix-ffmpeg-system-fallback/design.md
@@ -1,0 +1,31 @@
+## Context
+
+`checkAndSetupFfmpeg()` in `electron/main.js:19-59` tries to load the bundled `@ffmpeg-installer/ffmpeg` package and verify it with `-version`. If that fails (e.g., missing native binary for the platform, asar packaging issue), the outer catch sets `ffmpegAvailable = false` with no further attempts. A system-installed ffmpeg is ignored entirely.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fall back to system PATH ffmpeg/ffprobe when bundled binaries fail
+- Work cross-platform (macOS/Linux: `which`, Windows: `where`)
+- Maintain bundled binary as first preference
+
+**Non-Goals:**
+- Downloading ffmpeg automatically
+- Prompting the user to install ffmpeg
+- Changing how ffmpeg is used after setup
+
+## Decisions
+
+**1. Fallback in the existing catch block**
+Add the system lookup inside the existing `catch (error)` block at line 54. This keeps the bundled-first preference and only triggers when bundled fails. Alternative: separate function — unnecessary complexity for a simple fallback.
+
+**2. Use `which`/`where` via `execPromise`**
+`execPromise` is already available at module scope (line 12). `which` works on macOS and Linux; `where` is the Windows equivalent. The command output gives the absolute path. Alternative: `require('which')` package — adds a dependency for no benefit.
+
+**3. Verify with `-version` before accepting**
+Run `"<path>" -version` on the discovered binary to confirm it's functional, same pattern the bundled check uses at line 30.
+
+## Risks / Trade-offs
+
+- **[`which` not found on exotic shells]** → Extremely unlikely on any supported Electron platform; acceptable risk.
+- **[System ffmpeg too old]** → Out of scope; if it responds to `-version`, accept it. yt-dlp handles version compatibility separately.

--- a/openspec/changes/archive/2026-05-10-fix-ffmpeg-system-fallback/proposal.md
+++ b/openspec/changes/archive/2026-05-10-fix-ffmpeg-system-fallback/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+YouTube download fails with "missing ffmpeg" even when ffmpeg is installed system-wide, because `checkAndSetupFfmpeg()` only checks the bundled `@ffmpeg-installer/ffmpeg` binary and never falls back to the system PATH.
+
+## What Changes
+
+- Add system PATH fallback to `checkAndSetupFfmpeg()` when the bundled ffmpeg binary fails
+- Use `which ffmpeg` (Unix) / `where ffmpeg` (Windows) to locate system binary
+- Apply the same fallback pattern for ffprobe
+- Verify discovered system binaries with `-version` before accepting them
+
+## Capabilities
+
+### New Capabilities
+
+_None — this is a bugfix to existing behavior._
+
+### Modified Capabilities
+
+_None — no existing specs exist and no spec-level requirements are changing._
+
+## Impact
+
+- **Code**: `electron/main.js`, function `checkAndSetupFfmpeg()` (lines 19-59)
+- **Dependencies**: No new dependencies
+- **Platforms**: Must work on macOS, Linux, and Windows (different `which`/`where` commands)

--- a/openspec/changes/archive/2026-05-10-fix-ffmpeg-system-fallback/specs/ffmpeg-setup/spec.md
+++ b/openspec/changes/archive/2026-05-10-fix-ffmpeg-system-fallback/specs/ffmpeg-setup/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: System PATH ffmpeg fallback
+When the bundled ffmpeg binary fails, the system SHALL attempt to locate ffmpeg on the system PATH using `which ffmpeg` (Unix) or `where ffmpeg` (Windows) and verify it with `-version` before accepting.
+
+#### Scenario: Bundled ffmpeg fails, system ffmpeg available
+- **WHEN** the bundled `@ffmpeg-installer/ffmpeg` binary fails verification
+- **AND** ffmpeg is installed on the system PATH
+- **THEN** the system SHALL use the system ffmpeg path and set `ffmpegAvailable = true`
+
+#### Scenario: Bundled ffmpeg fails, no system ffmpeg
+- **WHEN** the bundled ffmpeg binary fails verification
+- **AND** ffmpeg is NOT on the system PATH
+- **THEN** `ffmpegAvailable` SHALL remain `false`
+
+### Requirement: System PATH ffprobe fallback
+When the bundled ffprobe binary fails, the system SHALL attempt to locate ffprobe on the system PATH and configure `fluent-ffmpeg` to use it.
+
+#### Scenario: Bundled ffprobe fails, system ffprobe available
+- **WHEN** the bundled ffprobe binary fails
+- **AND** ffprobe is installed on the system PATH
+- **THEN** the system SHALL set the ffprobe path via `ffmpeg.setFfprobePath()`
+
+#### Scenario: Bundled ffprobe fails, no system ffprobe
+- **WHEN** the bundled ffprobe binary fails
+- **AND** ffprobe is NOT on the system PATH
+- **THEN** ffprobe SHALL remain unconfigured (no error thrown)

--- a/openspec/changes/archive/2026-05-10-fix-ffmpeg-system-fallback/tasks.md
+++ b/openspec/changes/archive/2026-05-10-fix-ffmpeg-system-fallback/tasks.md
@@ -1,0 +1,15 @@
+## 1. System ffmpeg fallback
+
+- [x] 1.1 In the catch block of `checkAndSetupFfmpeg()` (line 54), add system PATH lookup using `execPromise` with `which ffmpeg` (Unix) or `where ffmpeg` (Windows)
+- [x] 1.2 On success, trim the output to get the path, verify with `"<path>" -version`, set `ffmpegPath` and `ffmpegAvailable = true`
+- [x] 1.3 Log which path is being used (`console.log('Using system ffmpeg:', path)`)
+
+## 2. System ffprobe fallback
+
+- [x] 2.1 In the inner catch block for ffprobe (line 43), after the existing adjacent-directory fallback fails, add system PATH lookup using `which ffprobe` / `where ffprobe`
+- [x] 2.2 On success, call `ffmpeg.setFfprobePath()` with the discovered path and log it
+
+## 3. Verification
+
+- [ ] 3.1 Test with bundled ffmpeg removed/broken to confirm system fallback activates (manual)
+- [ ] 3.2 Test on target platform that YouTube download works with system ffmpeg (manual)

--- a/openspec/specs/ffmpeg-setup/spec.md
+++ b/openspec/specs/ffmpeg-setup/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: System PATH ffmpeg fallback
+When the bundled ffmpeg binary fails, the system SHALL attempt to locate ffmpeg on the system PATH using `which ffmpeg` (Unix) or `where ffmpeg` (Windows) and verify it with `-version` before accepting.
+
+#### Scenario: Bundled ffmpeg fails, system ffmpeg available
+- **WHEN** the bundled `@ffmpeg-installer/ffmpeg` binary fails verification
+- **AND** ffmpeg is installed on the system PATH
+- **THEN** the system SHALL use the system ffmpeg path and set `ffmpegAvailable = true`
+
+#### Scenario: Bundled ffmpeg fails, no system ffmpeg
+- **WHEN** the bundled ffmpeg binary fails verification
+- **AND** ffmpeg is NOT on the system PATH
+- **THEN** `ffmpegAvailable` SHALL remain `false`
+
+### Requirement: System PATH ffprobe fallback
+When the bundled ffprobe binary fails, the system SHALL attempt to locate ffprobe on the system PATH and configure `fluent-ffmpeg` to use it.
+
+#### Scenario: Bundled ffprobe fails, system ffprobe available
+- **WHEN** the bundled ffprobe binary fails
+- **AND** ffprobe is installed on the system PATH
+- **THEN** the system SHALL set the ffprobe path via `ffmpeg.setFfprobePath()`
+
+#### Scenario: Bundled ffprobe fails, no system ffprobe
+- **WHEN** the bundled ffprobe binary fails
+- **AND** ffprobe is NOT on the system PATH
+- **THEN** ffprobe SHALL remain unconfigured (no error thrown)


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @Stevesibilia._

## Summary

- When the bundled ffmpeg binary fails (e.g., missing or incompatible), the app now falls back to a system-installed ffmpeg found via PATH
- Prevents YouTube audio downloads from silently failing when the bundled binary doesn't work on the user's platform