### PR TITLE
feat(cart): add cart slot hotkeys with config UI and global playback shortcuts

### DIFF
--- a/components/CartHotkeyConfig.vue
+++ b/components/CartHotkeyConfig.vue
@@ -154,6 +154,7 @@ onUnmounted(() => {
   margin: 0;
   font-size: 16px;
   font-weight: 600;
+  color: var(--color-text-primary);
 }
 
 .close-btn {
@@ -167,7 +168,7 @@ onUnmounted(() => {
 }
 
 .close-btn:hover {
-  color: var(--color-text);
+  color: var(--color-text-primary);
 }
 
 .config-body {
@@ -186,7 +187,7 @@ onUnmounted(() => {
 }
 
 .slot-row:hover {
-  background: var(--color-hover);
+  background: var(--color-surface-hover);
 }
 
 .slot-row.capturing {
@@ -208,7 +209,7 @@ onUnmounted(() => {
   font-family: monospace;
   font-size: 13px;
   font-weight: 600;
-  color: var(--color-text);
+  color: var(--color-text-primary);
   background: var(--color-background);
   border: 1px solid var(--color-border);
   border-radius: 4px;
@@ -238,13 +239,13 @@ onUnmounted(() => {
   cursor: pointer;
   border: 1px solid var(--color-border);
   background: var(--color-background);
-  color: var(--color-text);
+  color: var(--color-text-primary);
   transition: background-color 0.15s;
 }
 
 .reset-btn:hover,
 .done-btn:hover {
-  background: var(--color-hover);
+  background: var(--color-surface-hover);
 }
 
 .done-btn {

--- a/components/CartHotkeyConfig.vue
+++ b/components/CartHotkeyConfig.vue
@@ -1,0 +1,259 @@
+<template>
+  <div class="hotkey-config-overlay" @click.self="$emit('close')">
+    <div class="hotkey-config-panel">
+      <div class="config-header">
+        <h3>{{ t('cart.hotkeyConfig') }}</h3>
+        <button class="close-btn" @click="$emit('close')">&times;</button>
+      </div>
+
+      <div class="config-body">
+        <div
+          v-for="slot in 16"
+          :key="slot"
+          class="slot-row"
+          :class="{ capturing: capturingSlot === slot - 1, conflict: conflictSlot === slot - 1 }"
+          @click="startCapture(slot - 1)"
+        >
+          <span class="slot-index">{{ slot }}</span>
+          <span class="slot-binding">
+            <template v-if="capturingSlot === slot - 1">
+              {{ t('cart.pressAnyKey') }}
+            </template>
+            <template v-else>
+              {{ getLabel(slot - 1) }}
+            </template>
+          </span>
+          <span v-if="errorMessage && errorSlot === slot - 1" class="error-msg">{{ errorMessage }}</span>
+        </div>
+      </div>
+
+      <div class="config-footer">
+        <button class="reset-btn" @click="handleReset">{{ t('cart.resetDefaults') }}</button>
+        <button class="done-btn" @click="$emit('close')">{{ t('cart.close') }}</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { formatKeyLabel, eventToBinding, isReservedCombo } from '~/composables/useCartHotkeys';
+
+const emit = defineEmits<{
+  close: [];
+}>();
+
+const { t } = useLocalization();
+const { keyMappings, updateBinding, resetToDefaults } = useCartHotkeys();
+const { saveProject } = useProject();
+
+const capturingSlot = ref<number | null>(null);
+const errorMessage = ref<string | null>(null);
+const errorSlot = ref<number | null>(null);
+const conflictSlot = ref<number | null>(null);
+
+const getLabel = (slotIndex: number): string => {
+  const binding = keyMappings.value[slotIndex];
+  return binding ? formatKeyLabel(binding) : '—';
+};
+
+const startCapture = (slotIndex: number) => {
+  capturingSlot.value = slotIndex;
+  errorMessage.value = null;
+  errorSlot.value = null;
+  conflictSlot.value = null;
+};
+
+const handleKeydown = (e: KeyboardEvent) => {
+  if (capturingSlot.value === null) return;
+
+  // Ignore modifier-only key presses
+  if (['Control', 'Shift', 'Alt', 'Meta'].includes(e.key)) return;
+
+  e.preventDefault();
+  e.stopPropagation();
+
+  const binding = eventToBinding(e);
+
+  // Check for Escape — cancel capture
+  if (e.key === 'Escape') {
+    capturingSlot.value = null;
+    errorMessage.value = null;
+    errorSlot.value = null;
+    return;
+  }
+
+  // Check reserved combos
+  if (isReservedCombo(binding)) {
+    errorMessage.value = t('cart.reserved');
+    errorSlot.value = capturingSlot.value;
+    return;
+  }
+
+  // Try to update binding
+  const result = updateBinding(capturingSlot.value, binding);
+  if (result.conflict >= 0) {
+    errorMessage.value = `Already assigned to Slot ${result.conflict + 1}`;
+    errorSlot.value = capturingSlot.value;
+    conflictSlot.value = result.conflict;
+    return;
+  }
+
+  // Success
+  errorMessage.value = null;
+  errorSlot.value = null;
+  conflictSlot.value = null;
+  capturingSlot.value = null;
+  saveProject();
+};
+
+const handleReset = () => {
+  resetToDefaults();
+  saveProject();
+};
+
+onMounted(() => {
+  window.addEventListener('keydown', handleKeydown, true);
+});
+
+onUnmounted(() => {
+  window.removeEventListener('keydown', handleKeydown, true);
+});
+</script>
+
+<style scoped>
+.hotkey-config-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.hotkey-config-panel {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  width: 400px;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+}
+
+.config-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.config-header h3 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  font-size: 24px;
+  cursor: pointer;
+  color: var(--color-text-secondary);
+  padding: 0 4px;
+  line-height: 1;
+}
+
+.close-btn:hover {
+  color: var(--color-text);
+}
+
+.config-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 0;
+}
+
+.slot-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 20px;
+  cursor: pointer;
+  transition: background-color 0.1s;
+}
+
+.slot-row:hover {
+  background: var(--color-hover);
+}
+
+.slot-row.capturing {
+  background: var(--color-accent-bg, rgba(59, 130, 246, 0.1));
+}
+
+.slot-row.conflict {
+  background: rgba(239, 68, 68, 0.1);
+}
+
+.slot-index {
+  font-weight: 700;
+  font-size: 14px;
+  min-width: 24px;
+  color: var(--color-text-secondary);
+}
+
+.slot-binding {
+  font-family: monospace;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text);
+  background: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  padding: 2px 8px;
+  min-width: 60px;
+  text-align: center;
+}
+
+.error-msg {
+  font-size: 12px;
+  color: #ef4444;
+  margin-left: auto;
+}
+
+.config-footer {
+  display: flex;
+  justify-content: space-between;
+  padding: 12px 20px;
+  border-top: 1px solid var(--color-border);
+}
+
+.reset-btn,
+.done-btn {
+  padding: 6px 16px;
+  border-radius: 4px;
+  font-size: 13px;
+  cursor: pointer;
+  border: 1px solid var(--color-border);
+  background: var(--color-background);
+  color: var(--color-text);
+  transition: background-color 0.15s;
+}
+
+.reset-btn:hover,
+.done-btn:hover {
+  background: var(--color-hover);
+}
+
+.done-btn {
+  background: var(--color-accent, #3b82f6);
+  color: white;
+  border-color: transparent;
+}
+
+.done-btn:hover {
+  opacity: 0.9;
+}
+</style>

--- a/components/CartPlayer.vue
+++ b/components/CartPlayer.vue
@@ -2,6 +2,9 @@
   <div class="cart-player" ref="cartPlayerRef">
     <div class="cart-header">
       <h2>Cart Player</h2>
+      <button class="hotkey-config-btn" @click="showHotkeyConfig = true" :title="t('cart.configureHotkeys')">
+        <span class="config-icon">⌨</span>
+      </button>
     </div>
     
     <div class="cart-grid" :class="gridClass">
@@ -10,17 +13,27 @@
         :key="slot"
         :slot="slot - 1"
         :item="getCartItem(slot - 1)"
+        :keyLabel="getKeyLabel(slot - 1)"
       />
     </div>
+
+    <CartHotkeyConfig
+      v-if="showHotkeyConfig"
+      @close="showHotkeyConfig = false"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
 import type { AudioItem } from '~/types/project';
+import { formatKeyLabel } from '~/composables/useCartHotkeys';
 
 const { currentProject } = useProject();
 const { getCartItem } = useCartItems();
+const { keyMappings, mount: mountHotkeys, unmount: unmountHotkeys } = useCartHotkeys();
+const { t } = useLocalization();
 
+const showHotkeyConfig = ref(false);
 const cartPlayerRef = ref<HTMLElement | null>(null);
 const gridClass = ref('grid-cols-2');
 
@@ -42,8 +55,14 @@ const updateGridColumns = () => {
   }
 };
 
+const getKeyLabel = (slotIndex: number): string => {
+  const binding = keyMappings.value[slotIndex];
+  return binding ? formatKeyLabel(binding) : '';
+};
+
 onMounted(() => {
   if (import.meta.client) {
+    mountHotkeys();
     // Initial setup
     updateGridColumns();
     
@@ -57,6 +76,7 @@ onMounted(() => {
     }
     
     onUnmounted(() => {
+      unmountHotkeys();
       resizeObserver.disconnect();
     });
   }
@@ -75,6 +95,7 @@ onMounted(() => {
 .cart-header {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   padding: var(--spacing-md) var(--spacing-lg);
   min-height: 56px;
   box-sizing: border-box;
@@ -85,6 +106,24 @@ onMounted(() => {
 .cart-header h2 {
   font-size: 18px;
   font-weight: 600;
+}
+
+.hotkey-config-btn {
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  padding: 4px 8px;
+  cursor: pointer;
+  color: var(--color-text-secondary);
+  font-size: 16px;
+  display: flex;
+  align-items: center;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.hotkey-config-btn:hover {
+  background-color: var(--color-hover);
+  color: var(--color-text);
 }
 
 .cart-grid {

--- a/components/CartPlayer.vue
+++ b/components/CartPlayer.vue
@@ -122,8 +122,8 @@ onMounted(() => {
 }
 
 .hotkey-config-btn:hover {
-  background-color: var(--color-hover);
-  color: var(--color-text);
+  background-color: var(--color-surface-hover);
+  color: var(--color-text-primary);
 }
 
 .cart-grid {

--- a/components/CartSlot.vue
+++ b/components/CartSlot.vue
@@ -16,6 +16,7 @@
   >
     <div v-if="!hasItem" class="empty-slot" @click="handleImport">
       <span class="slot-number">{{ slot + 1 }}</span>
+      <span v-if="keyLabel" class="key-label">{{ keyLabel }}</span>
       <span class="slot-hint">{{ t('cart.clickToImport') }}</span>
     </div>
     
@@ -40,6 +41,7 @@
       <div class="slot-header" @click="handlePlay">
         <span class="slot-number">{{ slot + 1 }}</span>
         <span class="slot-name">{{ item.displayName }}</span>
+        <span v-if="keyLabel" class="key-label">{{ keyLabel }}</span>
       </div>
       
       <!-- Waveform/Progress section at bottom -->
@@ -127,6 +129,7 @@ import type { AudioItem } from '~/types/project';
 const props = defineProps<{
   slot: number;
   item: AudioItem | null;
+  keyLabel?: string;
 }>();
 
 const { currentProject, findItemByUuid, triggerWaveformUpdate } = useProject();
@@ -802,6 +805,17 @@ const handleDrop = async (e: DragEvent) => {
     padding-left: 4px;
     text-align: center;
   }
+
+  .key-label {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--color-text-secondary);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 3px;
+    padding: 1px 5px;
+    font-family: monospace;
+  }
 }
 
 .slot-content {
@@ -846,6 +860,19 @@ const handleDrop = async (e: DragEvent) => {
     -webkit-box-orient: vertical;
     line-height: 1.3;
     flex: 1;
+  }
+
+  .key-label {
+    font-size: 10px;
+    font-weight: 600;
+    color: var(--color-text-secondary);
+    background: rgba(0, 0, 0, 0.2);
+    border: 1px solid var(--color-border);
+    border-radius: 3px;
+    padding: 0 4px;
+    font-family: monospace;
+    flex-shrink: 0;
+    line-height: 1.6;
   }
 }
 

--- a/composables/useCartHotkeys.ts
+++ b/composables/useCartHotkeys.ts
@@ -67,7 +67,7 @@ export const eventToBinding = (e: KeyboardEvent): CartSlotKeyBinding => {
 export const useCartHotkeys = () => {
   const { currentProject, selectedItem, saveProject } = useProject();
   const { getCartItem } = useCartItems();
-  const { playCue, stopCue, activeCues } = useAudioEngine();
+  const { playCue, stopCue, pauseCue, resumeCue, activeCues } = useAudioEngine();
 
   /**
    * Get current key mappings, falling back to defaults.
@@ -122,24 +122,54 @@ export const useCartHotkeys = () => {
   };
 
   /**
-   * Toggle play/stop for the selected playlist item.
+   * Get the target audio item for global shortcuts.
+   * Prefers selectedItem, falls back to the first active cue.
+   */
+  const getTargetItem = (): AudioItem | null => {
+    // Try selected item first
+    if (selectedItem.value && selectedItem.value.type === 'audio') {
+      return selectedItem.value as AudioItem;
+    }
+    // Fall back to first active (playing) cue
+    if (activeCues.value.size > 0) {
+      const firstUuid = activeCues.value.keys().next().value;
+      if (firstUuid) {
+        const { findItemByUuid } = useProject();
+        const item = findItemByUuid(firstUuid);
+        if (item && item.type === 'audio') return item as AudioItem;
+        // Check cart-only items
+        const { getCartOnlyItem } = useCartItems();
+        const cartItem = getCartOnlyItem(firstUuid);
+        if (cartItem) return cartItem;
+      }
+    }
+    return null;
+  };
+
+  /**
+   * Toggle pause/resume for the target item. If stopped, start playing.
    */
   const togglePlayStop = () => {
-    if (!selectedItem.value || selectedItem.value.type !== 'audio') return;
-    const item = selectedItem.value as AudioItem;
+    const item = getTargetItem();
+    if (!item) return;
     if (activeCues.value.has(item.uuid)) {
-      stopCue(item.uuid);
+      const cue = activeCues.value.get(item.uuid);
+      if (cue && cue.isPaused) {
+        resumeCue(item.uuid);
+      } else {
+        pauseCue(item.uuid);
+      }
     } else {
       playCue(item);
     }
   };
 
   /**
-   * Toggle loop on the selected item's endBehavior.
+   * Toggle loop on the target item's endBehavior.
    */
   const toggleLoop = () => {
-    if (!selectedItem.value || selectedItem.value.type !== 'audio') return;
-    const item = selectedItem.value as AudioItem;
+    const item = getTargetItem();
+    if (!item) return;
     if (item.endBehavior.action === 'loop') {
       item.endBehavior = { action: 'nothing' };
     } else {
@@ -155,7 +185,7 @@ export const useCartHotkeys = () => {
     if (isTextInputFocused()) return;
     if (!currentProject.value) return;
 
-    // Space = toggle play/stop of selected item
+    // Space = toggle play/stop of selected or playing item
     if (e.key === ' ' && !e.ctrlKey && !e.altKey && !e.shiftKey) {
       e.preventDefault();
       e.stopPropagation();
@@ -163,7 +193,7 @@ export const useCartHotkeys = () => {
       return;
     }
 
-    // Right Shift = toggle loop on selected item
+    // Right Shift = toggle loop on selected or playing item
     if (e.key === 'Shift' && e.location === KeyboardEvent.DOM_KEY_LOCATION_RIGHT) {
       e.preventDefault();
       e.stopPropagation();

--- a/composables/useCartHotkeys.ts
+++ b/composables/useCartHotkeys.ts
@@ -1,0 +1,238 @@
+import type { CartSlotKeyBinding } from '~/types/project';
+import type { AudioItem } from '~/types/project';
+import { DEFAULT_CART_SLOT_KEYS } from '~/types/project';
+
+// Reserved combos that cannot be assigned to cart slots
+const RESERVED_COMBOS: CartSlotKeyBinding[] = [
+  { key: 's', ctrlKey: true, shiftKey: false, altKey: false },
+  { key: 'q', ctrlKey: true, shiftKey: false, altKey: false },
+  { key: 'w', ctrlKey: true, shiftKey: false, altKey: false },
+  { key: 'z', ctrlKey: true, shiftKey: false, altKey: false },
+  { key: 'n', ctrlKey: true, shiftKey: false, altKey: false },
+  { key: 'o', ctrlKey: true, shiftKey: false, altKey: false },
+  { key: 'a', ctrlKey: true, shiftKey: false, altKey: false },
+  { key: 'c', ctrlKey: true, shiftKey: false, altKey: false },
+  { key: 'v', ctrlKey: true, shiftKey: false, altKey: false },
+  { key: 'x', ctrlKey: true, shiftKey: false, altKey: false },
+  { key: 'y', ctrlKey: true, shiftKey: false, altKey: false },
+  { key: 'r', ctrlKey: true, shiftKey: false, altKey: false },
+  { key: 'F1', ctrlKey: false, shiftKey: false, altKey: false },
+  { key: ' ', ctrlKey: false, shiftKey: false, altKey: false },
+  { key: 'Shift', ctrlKey: false, shiftKey: false, altKey: false },
+];
+
+/**
+ * Check if two key bindings match.
+ */
+const bindingsMatch = (a: CartSlotKeyBinding, b: CartSlotKeyBinding): boolean => {
+  return a.key.toLowerCase() === b.key.toLowerCase()
+    && a.ctrlKey === b.ctrlKey
+    && a.shiftKey === b.shiftKey
+    && a.altKey === b.altKey;
+};
+
+/**
+ * Check if a binding is a reserved combo.
+ */
+export const isReservedCombo = (binding: CartSlotKeyBinding): boolean => {
+  return RESERVED_COMBOS.some(r => bindingsMatch(r, binding));
+};
+
+/**
+ * Format a key binding for display (e.g., "Ctrl+1", "Q", "0").
+ */
+export const formatKeyLabel = (binding: CartSlotKeyBinding): string => {
+  const parts: string[] = [];
+  if (binding.ctrlKey) parts.push('Ctrl');
+  if (binding.shiftKey) parts.push('Shift');
+  if (binding.altKey) parts.push('Alt');
+  // Capitalize single-letter keys
+  const keyLabel = binding.key.length === 1 ? binding.key.toUpperCase() : binding.key;
+  parts.push(keyLabel);
+  return parts.join('+');
+};
+
+/**
+ * Convert a KeyboardEvent to a CartSlotKeyBinding.
+ */
+export const eventToBinding = (e: KeyboardEvent): CartSlotKeyBinding => {
+  return {
+    key: e.key,
+    ctrlKey: e.ctrlKey || e.metaKey,
+    shiftKey: e.shiftKey,
+    altKey: e.altKey,
+  };
+};
+
+export const useCartHotkeys = () => {
+  const { currentProject, selectedItem, saveProject } = useProject();
+  const { getCartItem } = useCartItems();
+  const { playCue, stopCue, activeCues } = useAudioEngine();
+
+  /**
+   * Get current key mappings, falling back to defaults.
+   */
+  const keyMappings = computed(() => {
+    return currentProject.value?.cartSlotKeys ?? { ...DEFAULT_CART_SLOT_KEYS };
+  });
+
+  /**
+   * Trigger a cart slot by index — mirrors click behavior.
+   */
+  const triggerSlot = (slotIndex: number) => {
+    const item = getCartItem(slotIndex);
+    if (!item) return;
+
+    if (activeCues.value.has(item.uuid)) {
+      // Already playing — stop it (toggle behavior)
+      stopCue(item.uuid);
+    } else {
+      playCue(item);
+    }
+  };
+
+  /**
+   * Find which slot a key event maps to. Returns slot index or -1.
+   */
+  const findSlotForEvent = (e: KeyboardEvent): number => {
+    const mappings = keyMappings.value;
+    for (const [slotStr, binding] of Object.entries(mappings)) {
+      if (
+        e.key.toLowerCase() === binding.key.toLowerCase()
+        && (e.ctrlKey || e.metaKey) === binding.ctrlKey
+        && e.shiftKey === binding.shiftKey
+        && e.altKey === binding.altKey
+      ) {
+        return parseInt(slotStr, 10);
+      }
+    }
+    return -1;
+  };
+
+  /**
+   * Check if focus is on a text input element.
+   */
+  const isTextInputFocused = (): boolean => {
+    const el = document.activeElement;
+    if (!el) return false;
+    const tag = el.tagName.toLowerCase();
+    if (tag === 'input' || tag === 'textarea') return true;
+    if ((el as HTMLElement).isContentEditable) return true;
+    return false;
+  };
+
+  /**
+   * Toggle play/stop for the selected playlist item.
+   */
+  const togglePlayStop = () => {
+    if (!selectedItem.value || selectedItem.value.type !== 'audio') return;
+    const item = selectedItem.value as AudioItem;
+    if (activeCues.value.has(item.uuid)) {
+      stopCue(item.uuid);
+    } else {
+      playCue(item);
+    }
+  };
+
+  /**
+   * Toggle loop on the selected item's endBehavior.
+   */
+  const toggleLoop = () => {
+    if (!selectedItem.value || selectedItem.value.type !== 'audio') return;
+    const item = selectedItem.value as AudioItem;
+    if (item.endBehavior.action === 'loop') {
+      item.endBehavior = { action: 'nothing' };
+    } else {
+      item.endBehavior = { action: 'loop' };
+    }
+    saveProject();
+  };
+
+  /**
+   * Global keydown handler.
+   */
+  const handleKeydown = (e: KeyboardEvent) => {
+    if (isTextInputFocused()) return;
+    if (!currentProject.value) return;
+
+    // Space = toggle play/stop of selected item
+    if (e.key === ' ' && !e.ctrlKey && !e.altKey && !e.shiftKey) {
+      e.preventDefault();
+      e.stopPropagation();
+      togglePlayStop();
+      return;
+    }
+
+    // Right Shift = toggle loop on selected item
+    if (e.key === 'Shift' && e.location === KeyboardEvent.DOM_KEY_LOCATION_RIGHT) {
+      e.preventDefault();
+      e.stopPropagation();
+      toggleLoop();
+      return;
+    }
+
+    // Cart slot hotkeys
+    const slotIndex = findSlotForEvent(e);
+    if (slotIndex >= 0) {
+      e.preventDefault();
+      e.stopPropagation();
+      triggerSlot(slotIndex);
+    }
+  };
+
+  /**
+   * Update a slot's key binding. Returns conflict slot index or -1.
+   */
+  const updateBinding = (slotIndex: number, binding: CartSlotKeyBinding): { conflict: number } => {
+    if (!currentProject.value) return { conflict: -1 };
+
+    // Check for conflicts with other slots
+    const mappings = currentProject.value.cartSlotKeys ?? {};
+    for (const [slotStr, existing] of Object.entries(mappings)) {
+      const existingSlot = parseInt(slotStr, 10);
+      if (existingSlot !== slotIndex && bindingsMatch(existing, binding)) {
+        return { conflict: existingSlot };
+      }
+    }
+
+    // Apply the binding
+    if (!currentProject.value.cartSlotKeys) {
+      currentProject.value.cartSlotKeys = { ...DEFAULT_CART_SLOT_KEYS };
+    }
+    currentProject.value.cartSlotKeys[slotIndex] = binding;
+    return { conflict: -1 };
+  };
+
+  /**
+   * Reset all bindings to defaults.
+   */
+  const resetToDefaults = () => {
+    if (!currentProject.value) return;
+    currentProject.value.cartSlotKeys = { ...DEFAULT_CART_SLOT_KEYS };
+  };
+
+  // Lifecycle: register/unregister global listener
+  let mounted = false;
+
+  const mount = () => {
+    if (mounted) return;
+    window.addEventListener('keydown', handleKeydown);
+    mounted = true;
+  };
+
+  const unmount = () => {
+    if (!mounted) return;
+    window.removeEventListener('keydown', handleKeydown);
+    mounted = false;
+  };
+
+  return {
+    keyMappings,
+    triggerSlot,
+    mount,
+    unmount,
+    updateBinding,
+    resetToDefaults,
+    findSlotForEvent,
+  };
+};

--- a/composables/useProject.ts
+++ b/composables/useProject.ts
@@ -8,7 +8,7 @@ import type {
   Theme,
   CartItem
 } from '~/types/project';
-import { DEFAULT_THEME } from '~/types/project';
+import { DEFAULT_THEME, DEFAULT_CART_SLOT_KEYS } from '~/types/project';
 
 export const useProject = () => {
   const currentProject = useState<Project | null>('currentProject', () => null);
@@ -103,6 +103,7 @@ export const useProject = () => {
         folderPath,
         items: [],
         cartItems: [],
+        cartSlotKeys: { ...DEFAULT_CART_SLOT_KEYS },
         cartOnlyItems: [],
         theme: { ...DEFAULT_THEME },
         createdAt: new Date().toISOString(),
@@ -178,6 +179,11 @@ export const useProject = () => {
     // Add cartOnlyItems if missing
     if (!project.cartOnlyItems) {
       project.cartOnlyItems = [];
+    }
+    
+    // Add cartSlotKeys if missing — use defaults
+    if (!project.cartSlotKeys) {
+      project.cartSlotKeys = { ...DEFAULT_CART_SLOT_KEYS };
     }
     
     const migrateItem = (item: BaseItem) => {

--- a/locales/en.json
+++ b/locales/en.json
@@ -53,7 +53,16 @@
   "cart": {
     "title": "Cart Player",
     "emptySlot": "Click to import or drag item here",
-    "clickToImport": "Click to import or drag item here"
+    "clickToImport": "Click to import or drag item here",
+    "configureHotkeys": "Configure Hotkeys",
+    "hotkeyConfig": "Hotkey Configuration",
+    "slot": "Slot",
+    "currentBinding": "Current Binding",
+    "pressAnyKey": "Press any key...",
+    "conflict": "Already assigned to Slot {slot}",
+    "reserved": "This key combination is reserved",
+    "resetDefaults": "Reset to Defaults",
+    "close": "Close"
   },
   "properties": {
     "title": "Properties",

--- a/types/project.ts
+++ b/types/project.ts
@@ -90,6 +90,14 @@ export interface DuckingBehavior {
   duckFadeOut?: number; // fade out duration in seconds when restoring (default: 1)
 }
 
+// Cart slot key binding
+export interface CartSlotKeyBinding {
+  key: string;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+}
+
 // Cart player item
 export interface CartItem {
   slot: number; // 0-15
@@ -104,6 +112,7 @@ export interface Project {
   folderPath: string;
   items: (AudioItem | GroupItem)[];
   cartItems: CartItem[];
+  cartSlotKeys?: Record<number, CartSlotKeyBinding>;
   cartOnlyItems: AudioItem[]; // Items that exist only in cart (not in playlist)
   theme: Theme;
   createdAt: string;
@@ -201,4 +210,24 @@ export const DEFAULT_GROUP_ITEM: Partial<GroupItem> = {
   endBehavior: { action: 'nothing' },
   isExpanded: true,
   children: []
+};
+
+// Default cart slot key mappings: 1-9 → slots 0-8, 0 → slot 9, Ctrl+1-6 → slots 10-15
+export const DEFAULT_CART_SLOT_KEYS: Record<number, CartSlotKeyBinding> = {
+  0:  { key: '1', ctrlKey: false, shiftKey: false, altKey: false },
+  1:  { key: '2', ctrlKey: false, shiftKey: false, altKey: false },
+  2:  { key: '3', ctrlKey: false, shiftKey: false, altKey: false },
+  3:  { key: '4', ctrlKey: false, shiftKey: false, altKey: false },
+  4:  { key: '5', ctrlKey: false, shiftKey: false, altKey: false },
+  5:  { key: '6', ctrlKey: false, shiftKey: false, altKey: false },
+  6:  { key: '7', ctrlKey: false, shiftKey: false, altKey: false },
+  7:  { key: '8', ctrlKey: false, shiftKey: false, altKey: false },
+  8:  { key: '9', ctrlKey: false, shiftKey: false, altKey: false },
+  9:  { key: '0', ctrlKey: false, shiftKey: false, altKey: false },
+  10: { key: '1', ctrlKey: true, shiftKey: false, altKey: false },
+  11: { key: '2', ctrlKey: true, shiftKey: false, altKey: false },
+  12: { key: '3', ctrlKey: true, shiftKey: false, altKey: false },
+  13: { key: '4', ctrlKey: true, shiftKey: false, altKey: false },
+  14: { key: '5', ctrlKey: true, shiftKey: false, altKey: false },
+  15: { key: '6', ctrlKey: true, shiftKey: false, altKey: false },
 };


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @Stevesibilia._

## Summary

- Add keyboard shortcuts for all 16 cart slots with sensible defaults (1-9 for slots 1-9, 0 for slot 10, Ctrl+1-6 for slots 11-16)
- User-configurable key bindings stored in the project file with backward-compatible migration
- Config modal (keyboard icon in cart header) with press-any-key capture, conflict detection, and reserved combo protection
- Key labels displayed on each cart slot
- Space key toggles play/stop of the selected playlist item
- Right Shift toggles loop mode on the selected playlist item