### PR TITLE
feat(cart): add MIDI controller mapping with unified config modal

### DIFF
--- a/components/CartPlayer.vue
+++ b/components/CartPlayer.vue
@@ -2,9 +2,11 @@
   <div class="cart-player" ref="cartPlayerRef">
     <div class="cart-header">
       <h2>Cart Player</h2>
-      <button class="hotkey-config-btn" @click="showHotkeyConfig = true" :title="t('cart.configureHotkeys')">
-        <span class="config-icon">⌨</span>
-      </button>
+      <div class="header-buttons">
+        <button class="hotkey-config-btn" @click="showControlConfig = true" :title="t('cart.configureControls')">
+          <span class="config-icon">&#x2699;</span>
+        </button>
+      </div>
     </div>
     
     <div class="cart-grid" :class="gridClass">
@@ -17,9 +19,9 @@
       />
     </div>
 
-    <CartHotkeyConfig
-      v-if="showHotkeyConfig"
-      @close="showHotkeyConfig = false"
+    <ControlConfigModal
+      v-if="showControlConfig"
+      @close="showControlConfig = false"
     />
   </div>
 </template>
@@ -31,9 +33,10 @@ import { formatKeyLabel } from '~/composables/useCartHotkeys';
 const { currentProject } = useProject();
 const { getCartItem } = useCartItems();
 const { keyMappings, mount: mountHotkeys, unmount: unmountHotkeys } = useCartHotkeys();
+const { mount: mountMidi, unmount: unmountMidi } = useMidiController();
 const { t } = useLocalization();
 
-const showHotkeyConfig = ref(false);
+const showControlConfig = ref(false);
 const cartPlayerRef = ref<HTMLElement | null>(null);
 const gridClass = ref('grid-cols-2');
 
@@ -63,6 +66,7 @@ const getKeyLabel = (slotIndex: number): string => {
 onMounted(() => {
   if (import.meta.client) {
     mountHotkeys();
+    mountMidi();
     // Initial setup
     updateGridColumns();
     
@@ -77,6 +81,7 @@ onMounted(() => {
     
     onUnmounted(() => {
       unmountHotkeys();
+      unmountMidi();
       resizeObserver.disconnect();
     });
   }

--- a/components/ControlConfigModal.vue
+++ b/components/ControlConfigModal.vue
@@ -1,0 +1,612 @@
+<template>
+  <div class="control-config-overlay" @click.self="$emit('close')">
+    <div class="control-config-panel">
+      <div class="config-header">
+        <div class="header-left">
+          <h3>{{ t('cart.configureControls') }}</h3>
+          <span v-if="activeTab === 'midi' && connectedDevices.length > 0" class="device-info">
+            {{ connectedDevices.join(', ') }}
+          </span>
+          <span v-else-if="activeTab === 'midi'" class="device-info no-device">{{ t('midi.noDevices') }}</span>
+        </div>
+        <button class="close-btn" @click="$emit('close')">&times;</button>
+      </div>
+
+      <div class="tab-bar">
+        <button
+          class="tab-btn"
+          :class="{ active: activeTab === 'keyboard' }"
+          @click="activeTab = 'keyboard'"
+        >
+          <span class="tab-icon">&#x2328;</span> {{ t('cart.tabKeyboard') }}
+        </button>
+        <button
+          class="tab-btn"
+          :class="{ active: activeTab === 'midi' }"
+          @click="activeTab = 'midi'"
+        >
+          <span class="tab-icon">&#x1F3B9;</span> {{ t('cart.tabMidi') }}
+        </button>
+      </div>
+
+      <!-- Keyboard tab -->
+      <div v-if="activeTab === 'keyboard'" class="config-body">
+        <div
+          v-for="slot in 16"
+          :key="slot"
+          class="slot-row"
+          :class="{ capturing: capturingSlot === slot - 1, conflict: conflictSlot === slot - 1 }"
+          @click="startCapture(slot - 1)"
+        >
+          <span class="slot-index">{{ slot }}</span>
+          <span class="slot-binding">
+            <template v-if="capturingSlot === slot - 1">
+              {{ t('cart.pressAnyKey') }}
+            </template>
+            <template v-else>
+              {{ getKeyLabel(slot - 1) }}
+            </template>
+          </span>
+          <span v-if="keyErrorMessage && keyErrorSlot === slot - 1" class="error-msg">{{ keyErrorMessage }}</span>
+        </div>
+      </div>
+
+      <!-- MIDI tab -->
+      <div v-if="activeTab === 'midi'" class="config-body">
+        <template v-for="category in midiCategories" :key="category">
+          <div class="category-header">{{ category }}</div>
+          <div
+            v-for="action in midiActionsByCategory(category)"
+            :key="action.id"
+            class="action-row"
+            :class="{ learning: learning === action.id }"
+          >
+            <span class="action-label">{{ action.label }}</span>
+            <span class="action-binding">
+              <template v-if="learning === action.id">
+                {{ t('midi.waitingForInput') }}
+              </template>
+              <template v-else-if="getMidiBinding(action.id)">
+                {{ formatMidiBindingLabel(action.id) }}
+              </template>
+              <template v-else>
+                —
+              </template>
+            </span>
+            <div class="action-buttons">
+              <button
+                class="learn-btn"
+                :class="{ active: learning === action.id }"
+                @click="toggleLearn(action.id)"
+              >
+                {{ learning === action.id ? t('midi.cancel') : t('midi.learn') }}
+              </button>
+              <button
+                v-if="getMidiBinding(action.id)"
+                class="clear-btn"
+                @click="handleMidiClear(action.id)"
+              >
+                {{ t('midi.clear') }}
+              </button>
+            </div>
+          </div>
+        </template>
+      </div>
+
+      <div class="config-footer">
+        <button class="reset-btn" @click="handleReset">
+          {{ activeTab === 'keyboard' ? t('cart.resetDefaults') : t('midi.resetAll') }}
+        </button>
+        <button class="done-btn" @click="$emit('close')">{{ t('cart.close') }}</button>
+      </div>
+
+      <!-- MIDI Conflict dialog -->
+      <div v-if="midiConflictInfo" class="conflict-overlay" @click.self="midiConflictInfo = null">
+        <div class="conflict-dialog">
+          <p>{{ midiConflictMessage }}</p>
+          <div class="conflict-buttons">
+            <button class="cancel-btn" @click="midiConflictInfo = null">{{ t('midi.cancel') }}</button>
+            <button class="confirm-btn" @click="resolveMidiConflict">{{ t('midi.reassign') }}</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { formatKeyLabel, eventToBinding, isReservedCombo } from '~/composables/useCartHotkeys';
+import {
+  MIDI_ACTIONS,
+  formatMidiBinding,
+  type MidiBinding,
+  type MidiActionId,
+} from '~/composables/useMidiController';
+
+const emit = defineEmits<{
+  close: [];
+}>();
+
+const { t } = useLocalization();
+
+// Keyboard state
+const { keyMappings, updateBinding: updateKeyBinding, resetToDefaults } = useCartHotkeys();
+const { saveProject } = useProject();
+const capturingSlot = ref<number | null>(null);
+const keyErrorMessage = ref<string | null>(null);
+const keyErrorSlot = ref<number | null>(null);
+const conflictSlot = ref<number | null>(null);
+
+// MIDI state
+const {
+  config: midiConfig,
+  connectedDevices,
+  learning,
+  startLearn,
+  stopLearn,
+  updateBinding: updateMidiBinding,
+  clearBinding: clearMidiBinding,
+  clearAllBindings,
+} = useMidiController();
+
+const midiConflictInfo = ref<{ actionId: MidiActionId; binding: MidiBinding; conflictAction: string } | null>(null);
+
+const activeTab = ref<'keyboard' | 'midi'>('keyboard');
+
+// --- Keyboard helpers ---
+
+const getKeyLabel = (slotIndex: number): string => {
+  const binding = keyMappings.value[slotIndex];
+  return binding ? formatKeyLabel(binding) : '—';
+};
+
+const startCapture = (slotIndex: number) => {
+  capturingSlot.value = slotIndex;
+  keyErrorMessage.value = null;
+  keyErrorSlot.value = null;
+  conflictSlot.value = null;
+};
+
+const handleKeydown = (e: KeyboardEvent) => {
+  // Escape handling (works for both tabs)
+  if (e.key === 'Escape') {
+    if (activeTab.value === 'keyboard' && capturingSlot.value !== null) {
+      capturingSlot.value = null;
+      keyErrorMessage.value = null;
+      keyErrorSlot.value = null;
+      e.preventDefault();
+      return;
+    }
+    if (activeTab.value === 'midi' && learning.value) {
+      stopLearn();
+      e.preventDefault();
+      return;
+    }
+    emit('close');
+    return;
+  }
+
+  // Only capture keys in keyboard tab
+  if (activeTab.value !== 'keyboard' || capturingSlot.value === null) return;
+  if (['Control', 'Shift', 'Alt', 'Meta'].includes(e.key)) return;
+
+  e.preventDefault();
+  e.stopPropagation();
+
+  const binding = eventToBinding(e);
+
+  if (isReservedCombo(binding)) {
+    keyErrorMessage.value = t('cart.reserved');
+    keyErrorSlot.value = capturingSlot.value;
+    return;
+  }
+
+  const result = updateKeyBinding(capturingSlot.value, binding);
+  if (result.conflict >= 0) {
+    keyErrorMessage.value = `Already assigned to Slot ${result.conflict + 1}`;
+    keyErrorSlot.value = capturingSlot.value;
+    conflictSlot.value = result.conflict;
+    return;
+  }
+
+  keyErrorMessage.value = null;
+  keyErrorSlot.value = null;
+  conflictSlot.value = null;
+  capturingSlot.value = null;
+  saveProject();
+};
+
+// --- MIDI helpers ---
+
+const midiCategories = computed(() => {
+  const cats: string[] = [];
+  for (const action of MIDI_ACTIONS) {
+    if (!cats.includes(action.category)) cats.push(action.category);
+  }
+  return cats;
+});
+
+const midiActionsByCategory = (category: string) => {
+  return MIDI_ACTIONS.filter(a => a.category === category);
+};
+
+const getMidiBinding = (actionId: string): MidiBinding | undefined => {
+  return midiConfig.value.bindings[actionId];
+};
+
+const formatMidiBindingLabel = (actionId: string): string => {
+  const binding = midiConfig.value.bindings[actionId];
+  return binding ? formatMidiBinding(binding) : '';
+};
+
+const midiConflictMessage = computed(() => {
+  if (!midiConflictInfo.value) return '';
+  const conflictAction = MIDI_ACTIONS.find(a => a.id === midiConflictInfo.value!.conflictAction);
+  const label = conflictAction?.label ?? midiConflictInfo.value.conflictAction;
+  return `This control is already assigned to "${label}". Reassign it?`;
+});
+
+const toggleLearn = (actionId: MidiActionId) => {
+  if (learning.value === actionId) {
+    stopLearn();
+    return;
+  }
+  startLearn(actionId, (binding: MidiBinding) => {
+    stopLearn();
+    const result = updateMidiBinding(actionId, binding);
+    if (result.conflict) {
+      midiConflictInfo.value = { actionId, binding, conflictAction: result.conflict };
+    }
+  });
+};
+
+const resolveMidiConflict = () => {
+  if (!midiConflictInfo.value) return;
+  const { actionId, binding, conflictAction } = midiConflictInfo.value;
+  clearMidiBinding(conflictAction as MidiActionId);
+  updateMidiBinding(actionId, binding);
+  midiConflictInfo.value = null;
+};
+
+const handleMidiClear = (actionId: MidiActionId) => {
+  clearMidiBinding(actionId);
+};
+
+// --- Shared ---
+
+const handleReset = () => {
+  if (activeTab.value === 'keyboard') {
+    resetToDefaults();
+    saveProject();
+  } else {
+    clearAllBindings();
+  }
+};
+
+onMounted(() => {
+  window.addEventListener('keydown', handleKeydown, true);
+});
+
+onUnmounted(() => {
+  window.removeEventListener('keydown', handleKeydown, true);
+  if (learning.value) stopLearn();
+});
+</script>
+
+<style scoped>
+.control-config-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.control-config-panel {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  width: 520px;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  position: relative;
+}
+
+.config-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 16px 20px 12px;
+}
+
+.header-left {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.config-header h3 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.device-info {
+  font-size: 12px;
+  color: var(--color-success);
+}
+
+.device-info.no-device {
+  color: var(--color-text-disabled);
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  font-size: 24px;
+  cursor: pointer;
+  color: var(--color-text-secondary);
+  padding: 0 4px;
+  line-height: 1;
+}
+
+.close-btn:hover {
+  color: var(--color-text-primary);
+}
+
+/* Tabs */
+.tab-bar {
+  display: flex;
+  gap: 0;
+  padding: 0 20px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.tab-btn {
+  padding: 8px 16px;
+  font-size: 13px;
+  font-weight: 500;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.tab-btn:hover {
+  color: var(--color-text-primary);
+}
+
+.tab-btn.active {
+  color: var(--color-text-primary);
+  border-bottom-color: var(--color-accent, #3b82f6);
+}
+
+.tab-icon {
+  font-size: 15px;
+}
+
+/* Body */
+.config-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 0;
+}
+
+/* Keyboard tab rows */
+.slot-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 20px;
+  cursor: pointer;
+  transition: background-color 0.1s;
+}
+
+.slot-row:hover {
+  background: var(--color-surface-hover);
+}
+
+.slot-row.capturing {
+  background: rgba(59, 130, 246, 0.1);
+}
+
+.slot-row.conflict {
+  background: rgba(239, 68, 68, 0.1);
+}
+
+.slot-index {
+  font-weight: 700;
+  font-size: 14px;
+  min-width: 24px;
+  color: var(--color-text-secondary);
+}
+
+.slot-binding {
+  font-family: monospace;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  background: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  padding: 2px 8px;
+  min-width: 60px;
+  text-align: center;
+}
+
+.error-msg {
+  font-size: 12px;
+  color: #ef4444;
+  margin-left: auto;
+}
+
+/* MIDI tab rows */
+.category-header {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-secondary);
+  padding: 12px 20px 4px;
+}
+
+.action-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 20px;
+  transition: background-color 0.1s;
+}
+
+.action-row:hover {
+  background: var(--color-surface-hover);
+}
+
+.action-row.learning {
+  background: rgba(59, 130, 246, 0.1);
+}
+
+.action-label {
+  font-size: 13px;
+  color: var(--color-text-primary);
+  min-width: 120px;
+  flex-shrink: 0;
+}
+
+.action-binding {
+  font-family: monospace;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  background: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  padding: 2px 8px;
+  min-width: 90px;
+  text-align: center;
+  flex: 1;
+}
+
+.action-buttons {
+  display: flex;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.learn-btn,
+.clear-btn {
+  font-size: 11px;
+  padding: 3px 8px;
+  border-radius: 3px;
+  border: 1px solid var(--color-border);
+  background: var(--color-background);
+  color: var(--color-text-primary);
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.learn-btn:hover,
+.clear-btn:hover {
+  background: var(--color-surface-hover);
+}
+
+.learn-btn.active {
+  background: var(--color-accent, #3b82f6);
+  color: white;
+  border-color: transparent;
+}
+
+/* Footer */
+.config-footer {
+  display: flex;
+  justify-content: space-between;
+  padding: 12px 20px;
+  border-top: 1px solid var(--color-border);
+}
+
+.reset-btn,
+.done-btn {
+  padding: 6px 16px;
+  border-radius: 4px;
+  font-size: 13px;
+  cursor: pointer;
+  border: 1px solid var(--color-border);
+  background: var(--color-background);
+  color: var(--color-text-primary);
+  transition: background-color 0.15s;
+}
+
+.reset-btn:hover,
+.done-btn:hover {
+  background: var(--color-surface-hover);
+}
+
+.done-btn {
+  background: var(--color-accent, #3b82f6);
+  color: white;
+  border-color: transparent;
+}
+
+.done-btn:hover {
+  opacity: 0.9;
+}
+
+/* Conflict dialog */
+.conflict-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+}
+
+.conflict-dialog {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 20px;
+  max-width: 300px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+}
+
+.conflict-dialog p {
+  font-size: 13px;
+  color: var(--color-text-primary);
+  margin-bottom: 16px;
+}
+
+.conflict-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.cancel-btn,
+.confirm-btn {
+  padding: 6px 14px;
+  border-radius: 4px;
+  font-size: 13px;
+  cursor: pointer;
+  border: 1px solid var(--color-border);
+  background: var(--color-background);
+  color: var(--color-text-primary);
+}
+
+.confirm-btn {
+  background: var(--color-accent, #3b82f6);
+  color: white;
+  border-color: transparent;
+}
+</style>

--- a/composables/useAudioEngine.ts
+++ b/composables/useAudioEngine.ts
@@ -1,5 +1,5 @@
 import type { AudioItem, DuckingBehavior, GroupItem } from '~/types/project';
-import { Howl } from 'howler';
+import { Howl, Howler } from 'howler';
 import { linearToDb, dbToLinear, applyVolumeOffset as applyVolumeOffsetUtil, estimateCurrentLevel } from '~/utils/audio';
 
 // Active cue tracking with Howler instances
@@ -41,6 +41,16 @@ export const useAudioEngine = () => {
   const activeGroups = useState<Map<string, ActiveGroupState>>('activeGroups', () => new Map());
   const masterOutputLevel = useState<number>('masterOutputLevel', () => -60); // Master output level in dB
   const masterPeakLevel = useState<number>('masterPeakLevel', () => -60); // Master peak level in dB
+  const masterGainDb = useState<number>('masterGainDb', () => 0); // Master gain in dB (-60 to 0), 0 = unity
+
+  /**
+   * Set master gain and apply to Howler global volume.
+   */
+  const setMasterGain = (db: number) => {
+    const clamped = Math.max(-60, Math.min(0, db));
+    masterGainDb.value = clamped;
+    Howler.volume(clamped <= -60 ? 0 : dbToLinear(clamped));
+  };
 
   // Helper function to apply -10dB offset to volume
   // This allows the UI to show 0dB as "normal" while actually playing at -10dB
@@ -1312,6 +1322,8 @@ export const useAudioEngine = () => {
     activeGroups,
     masterOutputLevel,
     masterPeakLevel,
+    masterGainDb,
+    setMasterGain,
     playCue,
     stopCue,
     stopAllCues,

--- a/composables/useCartHotkeys.ts
+++ b/composables/useCartHotkeys.ts
@@ -123,14 +123,10 @@ export const useCartHotkeys = () => {
 
   /**
    * Get the target audio item for global shortcuts.
-   * Prefers selectedItem, falls back to the first active cue.
+   * Prefers the active (playing) cue, falls back to selectedItem.
    */
   const getTargetItem = (): AudioItem | null => {
-    // Try selected item first
-    if (selectedItem.value && selectedItem.value.type === 'audio') {
-      return selectedItem.value as AudioItem;
-    }
-    // Fall back to first active (playing) cue
+    // Try active (playing) cue first — pause/resume should target what's audible
     if (activeCues.value.size > 0) {
       const firstUuid = activeCues.value.keys().next().value;
       if (firstUuid) {
@@ -142,6 +138,10 @@ export const useCartHotkeys = () => {
         const cartItem = getCartOnlyItem(firstUuid);
         if (cartItem) return cartItem;
       }
+    }
+    // Fall back to selected item (e.g., to start playback when nothing is playing)
+    if (selectedItem.value && selectedItem.value.type === 'audio') {
+      return selectedItem.value as AudioItem;
     }
     return null;
   };

--- a/composables/useMidiController.ts
+++ b/composables/useMidiController.ts
@@ -120,11 +120,9 @@ export const useMidiController = () => {
     }
 
     if (actionId === 'pause-resume') {
-      // Same logic as keyboard Space
+      // Same logic as keyboard Space — prefer active cue over selectedItem
       let targetItem: AudioItem | null = null;
-      if (selectedItem.value && selectedItem.value.type === 'audio') {
-        targetItem = selectedItem.value as AudioItem;
-      } else if (activeCues.value.size > 0) {
+      if (activeCues.value.size > 0) {
         const firstUuid = activeCues.value.keys().next().value;
         if (firstUuid) {
           const { findItemByUuid } = useProject();
@@ -135,6 +133,9 @@ export const useMidiController = () => {
             targetItem = getCartOnlyItem(firstUuid);
           }
         }
+      }
+      if (!targetItem && selectedItem.value && selectedItem.value.type === 'audio') {
+        targetItem = selectedItem.value as AudioItem;
       }
       if (!targetItem) return;
       if (activeCues.value.has(targetItem.uuid)) {
@@ -152,9 +153,7 @@ export const useMidiController = () => {
 
     if (actionId === 'toggle-loop') {
       let targetItem: AudioItem | null = null;
-      if (selectedItem.value && selectedItem.value.type === 'audio') {
-        targetItem = selectedItem.value as AudioItem;
-      } else if (activeCues.value.size > 0) {
+      if (activeCues.value.size > 0) {
         const firstUuid = activeCues.value.keys().next().value;
         if (firstUuid) {
           const { findItemByUuid } = useProject();
@@ -165,6 +164,9 @@ export const useMidiController = () => {
             targetItem = getCartOnlyItem(firstUuid);
           }
         }
+      }
+      if (!targetItem && selectedItem.value && selectedItem.value.type === 'audio') {
+        targetItem = selectedItem.value as AudioItem;
       }
       if (!targetItem) return;
       if (targetItem.endBehavior.action === 'loop') {

--- a/composables/useMidiController.ts
+++ b/composables/useMidiController.ts
@@ -1,0 +1,397 @@
+import type { AudioItem } from '~/types/project';
+
+// MIDI binding: identifies a specific control on a MIDI device
+export interface MidiBinding {
+  channel: number;   // 0-15
+  type: 'note' | 'cc' | 'pitchbend';
+  number: number;    // note number, CC number (0-127), or 0 for pitchbend
+}
+
+// Available action IDs
+export type MidiActionId =
+  | 'trigger-slot-0' | 'trigger-slot-1' | 'trigger-slot-2' | 'trigger-slot-3'
+  | 'trigger-slot-4' | 'trigger-slot-5' | 'trigger-slot-6' | 'trigger-slot-7'
+  | 'trigger-slot-8' | 'trigger-slot-9' | 'trigger-slot-10' | 'trigger-slot-11'
+  | 'trigger-slot-12' | 'trigger-slot-13' | 'trigger-slot-14' | 'trigger-slot-15'
+  | 'pause-resume' | 'toggle-loop' | 'stop-all' | 'master-volume';
+
+// Config stored in midi-config.json
+export interface MidiConfig {
+  bindings: Record<string, MidiBinding>; // actionId → binding
+}
+
+// All available actions with display metadata
+export const MIDI_ACTIONS: { id: MidiActionId; label: string; category: string; continuous: boolean }[] = [
+  // Cart slots
+  ...Array.from({ length: 16 }, (_, i) => ({
+    id: `trigger-slot-${i}` as MidiActionId,
+    label: `Cart Slot ${i + 1}`,
+    category: 'Cart Slots',
+    continuous: false,
+  })),
+  // Playback
+  { id: 'pause-resume', label: 'Pause / Resume', category: 'Playback', continuous: false },
+  { id: 'toggle-loop', label: 'Toggle Loop', category: 'Playback', continuous: false },
+  { id: 'stop-all', label: 'Stop All', category: 'Playback', continuous: false },
+  // Volume
+  { id: 'master-volume', label: 'Master Volume', category: 'Volume', continuous: true },
+];
+
+/**
+ * Format a MIDI binding for display (e.g., "Ch1 Note 36", "Ch1 CC 9").
+ */
+export const formatMidiBinding = (binding: MidiBinding): string => {
+  const ch = `Ch${binding.channel + 1}`;
+  if (binding.type === 'pitchbend') return `${ch} Fader`;
+  const type = binding.type === 'note' ? 'Note' : 'CC';
+  return `${ch} ${type} ${binding.number}`;
+};
+
+/**
+ * Check if two MIDI bindings match.
+ */
+const bindingsMatch = (a: MidiBinding, b: MidiBinding): boolean => {
+  return a.channel === b.channel && a.type === b.type && a.number === b.number;
+};
+
+/**
+ * Parse a raw MIDI message into channel, type, number, value.
+ */
+const parseMidiMessage = (data: Uint8Array): { channel: number; type: 'note' | 'cc' | 'pitchbend' | 'other'; number: number; value: number } | null => {
+  if (data.length < 2) return null;
+  const status = data[0];
+  const channel = status & 0x0F;
+  const messageType = status & 0xF0;
+
+  if (data.length >= 3 && messageType === 0x90 && data[2] > 0) {
+    // Note On (velocity > 0)
+    return { channel, type: 'note', number: data[1], value: data[2] };
+  }
+  if (data.length >= 3 && (messageType === 0x80 || (messageType === 0x90 && data[2] === 0))) {
+    // Note Off
+    return { channel, type: 'note', number: data[1], value: 0 };
+  }
+  if (data.length >= 3 && messageType === 0xB0) {
+    // Control Change
+    return { channel, type: 'cc', number: data[1], value: data[2] };
+  }
+  if (data.length >= 3 && messageType === 0xE0) {
+    // Pitchbend: 14-bit value from two 7-bit bytes, scaled to 0-127
+    const raw14 = data[1] | (data[2] << 7); // 0-16383
+    const value = Math.round(raw14 / 128); // scale to 0-127
+    return { channel, type: 'pitchbend', number: 0, value };
+  }
+  return null;
+};
+
+// Shared singleton state (module-level so all useMidiController() calls share it)
+const config = ref<MidiConfig>({ bindings: {} });
+const midiAccess = ref<MIDIAccess | null>(null);
+const connectedDevices = ref<string[]>([]);
+const learning = ref<MidiActionId | null>(null);
+const lastMidiMessage = ref<MidiBinding | null>(null);
+let onLearnCapture: ((binding: MidiBinding) => void) | null = null;
+let mounted = false;
+
+export const useMidiController = () => {
+  const { getCartItem } = useCartItems();
+  const { playCue, stopCue, pauseCue, resumeCue, stopAllCues, activeCues, setMasterGain } = useAudioEngine();
+  const { selectedItem, saveProject } = useProject();
+
+  /**
+   * Dispatch a discrete action.
+   */
+  const dispatchDiscrete = (actionId: MidiActionId) => {
+    if (actionId.startsWith('trigger-slot-')) {
+      const slot = parseInt(actionId.replace('trigger-slot-', ''), 10);
+      const item = getCartItem(slot);
+      if (!item) return;
+      if (activeCues.value.has(item.uuid)) {
+        const cue = activeCues.value.get(item.uuid);
+        if (cue && cue.isPaused) {
+          resumeCue(item.uuid);
+        } else {
+          stopCue(item.uuid);
+        }
+      } else {
+        playCue(item);
+      }
+      return;
+    }
+
+    if (actionId === 'pause-resume') {
+      // Same logic as keyboard Space
+      let targetItem: AudioItem | null = null;
+      if (selectedItem.value && selectedItem.value.type === 'audio') {
+        targetItem = selectedItem.value as AudioItem;
+      } else if (activeCues.value.size > 0) {
+        const firstUuid = activeCues.value.keys().next().value;
+        if (firstUuid) {
+          const { findItemByUuid } = useProject();
+          const found = findItemByUuid(firstUuid);
+          if (found && found.type === 'audio') targetItem = found as AudioItem;
+          if (!targetItem) {
+            const { getCartOnlyItem } = useCartItems();
+            targetItem = getCartOnlyItem(firstUuid);
+          }
+        }
+      }
+      if (!targetItem) return;
+      if (activeCues.value.has(targetItem.uuid)) {
+        const cue = activeCues.value.get(targetItem.uuid);
+        if (cue && cue.isPaused) {
+          resumeCue(targetItem.uuid);
+        } else {
+          pauseCue(targetItem.uuid);
+        }
+      } else {
+        playCue(targetItem);
+      }
+      return;
+    }
+
+    if (actionId === 'toggle-loop') {
+      let targetItem: AudioItem | null = null;
+      if (selectedItem.value && selectedItem.value.type === 'audio') {
+        targetItem = selectedItem.value as AudioItem;
+      } else if (activeCues.value.size > 0) {
+        const firstUuid = activeCues.value.keys().next().value;
+        if (firstUuid) {
+          const { findItemByUuid } = useProject();
+          const found = findItemByUuid(firstUuid);
+          if (found && found.type === 'audio') targetItem = found as AudioItem;
+          if (!targetItem) {
+            const { getCartOnlyItem } = useCartItems();
+            targetItem = getCartOnlyItem(firstUuid);
+          }
+        }
+      }
+      if (!targetItem) return;
+      if (targetItem.endBehavior.action === 'loop') {
+        targetItem.endBehavior = { action: 'nothing' };
+      } else {
+        targetItem.endBehavior = { action: 'loop' };
+      }
+      saveProject();
+      return;
+    }
+
+    if (actionId === 'stop-all') {
+      stopAllCues();
+      return;
+    }
+  };
+
+  /**
+   * Dispatch a continuous action (CC value 0-127).
+   */
+  const dispatchContinuous = (actionId: MidiActionId, value: number) => {
+    if (actionId === 'master-volume') {
+      // Map CC 0-127 to -60dB to 0dB (linear in dB)
+      const db = -60 + (value / 127) * 60;
+      setMasterGain(db);
+    }
+  };
+
+  /**
+   * Handle an incoming MIDI message.
+   */
+  const handleMidiMessage = (event: MIDIMessageEvent) => {
+    const data = event.data;
+    if (!data) return;
+
+    const parsed = parseMidiMessage(data);
+    if (!parsed || parsed.type === 'other') return;
+
+    const binding: MidiBinding = { channel: parsed.channel, type: parsed.type as MidiBinding['type'], number: parsed.number };
+    lastMidiMessage.value = binding;
+
+    // MIDI Learn mode: capture this message
+    if (learning.value !== null) {
+      if (onLearnCapture) {
+        onLearnCapture(binding);
+      }
+      return;
+    }
+
+    // Look up binding in config
+    for (const [actionId, configured] of Object.entries(config.value.bindings)) {
+      if (bindingsMatch(configured, binding)) {
+        const action = MIDI_ACTIONS.find(a => a.id === actionId);
+        if (!action) continue;
+
+        if (action.continuous) {
+          dispatchContinuous(actionId as MidiActionId, parsed.value);
+        } else if (parsed.type === 'pitchbend') {
+          // Pitchbend as discrete: trigger at top of range
+          if (parsed.value > 63) {
+            dispatchDiscrete(actionId as MidiActionId);
+          }
+        } else {
+          // Only trigger on note-on or CC > 63 (button press)
+          if (parsed.type === 'note' && parsed.value > 0) {
+            dispatchDiscrete(actionId as MidiActionId);
+          } else if (parsed.type === 'cc' && parsed.value > 63) {
+            dispatchDiscrete(actionId as MidiActionId);
+          }
+        }
+        break;
+      }
+    }
+  };
+
+  /**
+   * Update connected device list.
+   */
+  const updateDeviceList = () => {
+    if (!midiAccess.value) {
+      connectedDevices.value = [];
+      return;
+    }
+    const names: string[] = [];
+    midiAccess.value.inputs.forEach((input) => {
+      if (input.name) names.push(input.name);
+    });
+    connectedDevices.value = names;
+  };
+
+  /**
+   * Attach listeners to all MIDI input ports.
+   */
+  const attachListeners = () => {
+    if (!midiAccess.value) return;
+    midiAccess.value.inputs.forEach((input) => {
+      input.onmidimessage = handleMidiMessage;
+    });
+  };
+
+  /**
+   * Request MIDI access and set up listeners.
+   */
+  const initMidi = async () => {
+    if (!navigator.requestMIDIAccess) {
+      console.warn('[MIDI] Web MIDI API not available');
+      return;
+    }
+    try {
+      const access = await navigator.requestMIDIAccess({ sysex: false });
+      midiAccess.value = access;
+
+      attachListeners();
+      updateDeviceList();
+
+      // Handle hot-plug
+      access.onstatechange = () => {
+        attachListeners();
+        updateDeviceList();
+      };
+    } catch (err) {
+      console.error('[MIDI] Failed to request MIDI access:', err);
+    }
+  };
+
+  /**
+   * Load config from main process.
+   */
+  const loadConfig = async () => {
+    if (import.meta.client && window.electronAPI) {
+      const data = await window.electronAPI.readMidiConfig();
+      if (data && data.bindings) {
+        config.value = data as MidiConfig;
+      }
+    }
+  };
+
+  /**
+   * Save config to main process.
+   */
+  const saveConfig = async () => {
+    if (import.meta.client && window.electronAPI) {
+      await window.electronAPI.writeMidiConfig(config.value);
+    }
+  };
+
+  /**
+   * Start MIDI Learn mode for an action.
+   */
+  const startLearn = (actionId: MidiActionId, callback: (binding: MidiBinding) => void) => {
+    learning.value = actionId;
+    onLearnCapture = callback;
+  };
+
+  /**
+   * Stop MIDI Learn mode.
+   */
+  const stopLearn = () => {
+    learning.value = null;
+    onLearnCapture = null;
+  };
+
+  /**
+   * Update a binding. Returns conflict action ID or null.
+   */
+  const updateBinding = (actionId: MidiActionId, binding: MidiBinding): { conflict: string | null } => {
+    // Check for conflicts
+    for (const [existingAction, existingBinding] of Object.entries(config.value.bindings)) {
+      if (existingAction !== actionId && bindingsMatch(existingBinding, binding)) {
+        return { conflict: existingAction };
+      }
+    }
+    config.value.bindings[actionId] = binding;
+    saveConfig();
+    return { conflict: null };
+  };
+
+  /**
+   * Clear a binding.
+   */
+  const clearBinding = (actionId: MidiActionId) => {
+    delete config.value.bindings[actionId];
+    saveConfig();
+  };
+
+  /**
+   * Clear all bindings.
+   */
+  const clearAllBindings = () => {
+    config.value.bindings = {};
+    saveConfig();
+  };
+
+  /**
+   * Mount: init MIDI and load config.
+   */
+  const mount = async () => {
+    if (mounted) return;
+    mounted = true;
+    await loadConfig();
+    await initMidi();
+  };
+
+  /**
+   * Unmount: detach listeners.
+   */
+  const unmount = () => {
+    if (!mounted) return;
+    mounted = false;
+    if (midiAccess.value) {
+      midiAccess.value.inputs.forEach((input) => {
+        input.onmidimessage = null;
+      });
+    }
+  };
+
+  return {
+    config,
+    connectedDevices,
+    learning,
+    lastMidiMessage,
+    mount,
+    unmount,
+    startLearn,
+    stopLearn,
+    updateBinding,
+    clearBinding,
+    clearAllBindings,
+  };
+};

--- a/electron/main.js
+++ b/electron/main.js
@@ -2000,6 +2000,32 @@ function openFile(filePath) {
   }
 }
 
+// MIDI Config Handlers
+const midiConfigPath = path.join(app.getPath('userData'), 'midi-config.json');
+
+ipcMain.handle('read-midi-config', async () => {
+  try {
+    if (fs.existsSync(midiConfigPath)) {
+      const data = fs.readFileSync(midiConfigPath, 'utf-8');
+      return JSON.parse(data);
+    }
+    return {};
+  } catch (error) {
+    console.error('Failed to read MIDI config:', error);
+    return {};
+  }
+});
+
+ipcMain.handle('write-midi-config', async (event, config) => {
+  try {
+    fs.writeFileSync(midiConfigPath, JSON.stringify(config, null, 2), 'utf-8');
+    return { success: true };
+  } catch (error) {
+    console.error('Failed to write MIDI config:', error);
+    throw new Error('Failed to save MIDI configuration');
+  }
+});
+
 app.on('window-all-closed', () => {
   if (apiServer) {
     apiServer.close();

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -134,5 +134,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   updateAppState: (state) => ipcRenderer.send('update-app-state', state),
   
   // Check if dev mode is enabled
-  isDevMode: () => ipcRenderer.invoke('is-dev-mode')
+  isDevMode: () => ipcRenderer.invoke('is-dev-mode'),
+
+  // MIDI config
+  readMidiConfig: () => ipcRenderer.invoke('read-midi-config'),
+  writeMidiConfig: (config) => ipcRenderer.invoke('write-midi-config', config)
 });

--- a/locales/en.json
+++ b/locales/en.json
@@ -55,7 +55,10 @@
     "emptySlot": "Click to import or drag item here",
     "clickToImport": "Click to import or drag item here",
     "configureHotkeys": "Configure Hotkeys",
+    "configureControls": "Configure Controls",
     "hotkeyConfig": "Hotkey Configuration",
+    "tabKeyboard": "Keyboard",
+    "tabMidi": "MIDI",
     "slot": "Slot",
     "currentBinding": "Current Binding",
     "pressAnyKey": "Press any key...",
@@ -200,6 +203,17 @@
   "importProgress": {
     "title": "Importing Project",
     "message": "Extracting"
+  },
+  "midi": {
+    "configTitle": "MIDI Controller Configuration",
+    "learn": "Learn",
+    "cancel": "Cancel",
+    "clear": "Clear",
+    "resetAll": "Reset All",
+    "close": "Close",
+    "waitingForInput": "Waiting for MIDI input...",
+    "noDevices": "No MIDI devices detected",
+    "reassign": "Already assigned to {action}. Reassign?"
   },
   "selectProject": {
     "title": "Select Project",

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -87,6 +87,8 @@ declare global {
       onApiUpdateCartItem: (callback: (event: any, data: { requestId: string; slot: number; updates: Record<string, any> }) => void) => void;
       onOpenProjectFile: (callback: (event: any, data: { filePath: string; projectData: any }) => void) => void;
       onOpenLpaFile: (callback: (event: any, data: { lpaPath: string }) => void) => void;
+      readMidiConfig: () => Promise<Record<string, any>>;
+      writeMidiConfig: (config: Record<string, any>) => Promise<{ success: boolean }>;
     };
   }
 


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @Stevesibilia._

## Summary

- Add Web MIDI API integration for detecting and handling MIDI input devices
- Implement MIDI Learn mode for binding MIDI controls (note, CC, pitchbend) to cart actions (play/pause, stop, volume)
- Create unified ControlConfigModal with tabs for keyboard hotkeys and MIDI mappings
- Add master volume control via MIDI fader (pitchbend) using `setMasterGain(db)`
- Persist MIDI config globally via IPC (`readMidiConfig`/`writeMidiConfig`)
- Fix Space key targeting: active cue takes priority over selectedItem

## Changes

| File | Change |
|------|--------|
| `composables/useMidiController.ts` | New — module-level singleton, MIDI Learn, pitchbend support |
| `components/ControlConfigModal.vue` | New — unified tabbed modal for keyboard + MIDI config |
| `components/CartPlayer.vue` | Integrate MIDI mount/unmount lifecycle, single config button |
| `composables/useAudioEngine.ts` | Add `setMasterGain(db)` via `Howler.volume()` |
| `composables/useCartHotkeys.ts` | Fix `getTargetItem()` to prioritize active cue |
| `electron/main.js` | Add MIDI config IPC handlers + file persistence |
| `electron/preload.js` | Expose `readMidiConfig`/`writeMidiConfig` via contextBridge |
| `types/global.d.ts` | Type declarations for MIDI IPC |
| `locales/en.json` | MIDI-related translation strings |

## Testing

- Tested with Behringer X-Touch Mini (pitchbend fader, note buttons, CC knobs)
- MIDI Learn mode detects input and binds to selected action
- Conflict detection prevents duplicate bindings
- Master volume responds to fader in real-time
- Config persists across app restarts