### PR TITLE
feat(welcome): add recent projects and project-folder defaults

### DIFF
--- a/client/app/components/AudioImportModal.vue
+++ b/client/app/components/AudioImportModal.vue
@@ -21,7 +21,7 @@
 
         <!-- "On server" tab — browses the server's filesystem via /api/fs/list -->
         <section v-if="tab === 'server'" class="pane">
-          <ServerFileBrowser :start-path="server.serverUrl ? '' : ''" @select="onServerPick" />
+          <ServerFileBrowser :start-path="projectStartPath" @select="onServerPick" />
           <p class="hint">{{ t('importAudio.serverHint') }}</p>
 
           <!-- Local file picker: only shown on local server (Electron only) -->
@@ -100,21 +100,24 @@
     both local and remote-server modes behave identically downstream.
 -->
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 import { useLiveplayServer } from '~/composables/useLiveplayServer';
 import ServerFileBrowser from '~/components/ServerFileBrowser.vue';
 
-const props = defineProps<{ open: boolean }>();
+defineProps<{ open: boolean }>();
 const emit  = defineEmits<{
   (e: 'pick', serverPaths: string[]): void;
   (e: 'close'): void;
 }>();
 
 const server = useLiveplayServer();
+const { currentProject } = useProject();
 const { t }  = useLocalization();
 // When the server is on this same machine, "Upload from this computer" is
 // meaningless — we just want the server file browser.
 const tab    = ref<'server' | 'upload'>('server');
+
+const projectStartPath = computed(() => currentProject.value?.folderPath || '');
 
 const uploading           = ref(false);
 const uploadStatus        = ref<string>('');
@@ -302,23 +305,14 @@ async function pickAndUpload() {
     border: 1px solid #2a2a2a; border-radius: 4px; background: #161616;
     max-height: 200px; overflow: auto;
     li {
-      display: grid; grid-template-columns: 28px 1fr; gap: 8px;
-      align-items: center; padding: 6px 10px;
-      border-bottom: 1px solid #222;
-      cursor: pointer; user-select: none;
-      &:last-child { border-bottom: none; }
-      &:hover { background: #1f1f1f; }
-      // Files are selectable here, so their icon takes the accent colour.
-      .icon { font-size: 18px; color: var(--color-accent); text-align: center; }
-      .name { color: #fff; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-      &.selected {
-        background: var(--color-accent);
-        .icon, .name { color: #fff; }
-      }
+      display: grid; grid-template-columns: 26px 1fr; gap: 8px; align-items: center;
+      padding: 6px 10px; border-bottom: 1px solid #222; cursor: pointer;
+      &:hover { background: #202020; }
+      &.selected { background: var(--color-accent); .name, .icon { color: #fff; } }
+      .icon { font-size: 18px; color: var(--color-accent); }
+      .name { color: #fff; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
     }
   }
-  .list-footer {
-    display: flex; justify-content: flex-end;
-  }
+  .list-footer { display: flex; justify-content: flex-end; }
 }
 </style>

--- a/client/app/components/WelcomeScreen.vue
+++ b/client/app/components/WelcomeScreen.vue
@@ -159,6 +159,31 @@
             <span>{{ t('welcome.openProject') }}</span>
           </button>
         </div>
+
+        <div v-if="recentProjects.length > 0" class="discovered-servers recent-projects">
+          <div class="discovered-header">
+            <span class="material-symbols-rounded">history</span>
+            <span>{{ t('menu.openRecent') }}</span>
+          </div>
+          <button
+            v-for="project in recentProjects"
+            :key="project.path"
+            class="discovered-row recent-project-row"
+            @click="openRecentProject(project)"
+          >
+            <span class="material-symbols-rounded discovered-icon">description</span>
+            <span class="discovered-main">
+              <span class="discovered-name">{{ project.name || projectBasename(project.path) }}</span>
+              <span class="discovered-meta">{{ project.folderPath || projectFolder(project.path) }}</span>
+            </span>
+            <span
+              class="material-symbols-rounded discovered-remove"
+              @click.stop="removeRecentProject(project)"
+              :title="t('welcome.forget')"
+            >close</span>
+          </button>
+        </div>
+        <p v-else class="discovered-empty recent-projects-empty">{{ t('menu.noRecentProjects') }}</p>
       </div>
     </div>
 
@@ -250,6 +275,14 @@ type RecentServer = { url: string; name: string; host: string; port: number; las
 const recentServers = ref<RecentServer[]>([]);
 const scanning = ref(false);
 
+type RecentProject = {
+  path: string;
+  name?: string;
+  folderPath?: string;
+  lastOpened?: number;
+};
+const recentProjects = ref<RecentProject[]>([]);
+
 // Computed reflection of the currently-configured server URL.
 const serverUrlDisplay = computed(() => server.serverUrl ?? 'http://127.0.0.1:4480');
 
@@ -286,6 +319,8 @@ onMounted(async () => {
   } catch (e) {
     console.warn('[welcome] could not read liveplay-server config:', e);
   }
+
+  await loadRecentProjects();
 
   // A double-clicked .liveplay/.lpa takes precedence over everything below:
   // it drives its own server-connection + open/import flow.
@@ -349,6 +384,10 @@ onMounted(async () => {
   } catch (e) {
     console.warn('[welcome] discovery start failed:', e);
   }
+});
+
+watch(stage, (s) => {
+  if (s === 'project') void loadRecentProjects();
 });
 
 // Drive a double-clicked file. For .liveplay: force local, start the server,
@@ -620,13 +659,67 @@ async function forgetRecent(srv: RecentServer) {
   } catch {}
 }
 
+// ---- Recent project helpers ------------------------------------------------
+
+async function loadRecentProjects() {
+  if (!import.meta.client) return;
+  try {
+    const api = (window as any).electronAPI?.liveplayProjects;
+    const list = await api?.recentList?.();
+    recentProjects.value = Array.isArray(list) ? list : [];
+  } catch (e) {
+    console.warn('[welcome] could not load recent projects:', e);
+    recentProjects.value = [];
+  }
+}
+
+function projectBasename(path: string): string {
+  return path.split(/[\\/]/).pop() || path;
+}
+
+function projectFolder(path: string): string {
+  return path.replace(/[\\/][^\\/]*$/, '');
+}
+
+function recentProjectStartPath(): string {
+  const first = recentProjects.value[0];
+  return first?.folderPath || (first?.path ? projectFolder(first.path) : '');
+}
+
+async function openRecentProject(project: RecentProject) {
+  if (!project.path) return;
+
+  const ok = await openProject(project.path);
+
+  if (!ok) {
+    console.warn('[welcome] failed to open recent project:', project.path);
+    alert(
+      `Failed to open project.\n\n` +
+      `LivePlay could not load this recent project from the current server. ` +
+      `The file may exist, but it may be unavailable, locked, not fully synced, or not readable by the server.\n\n` +
+      `Recent entry:\n${project.path}\n\n` +
+      `The entry was not removed. You can remove it manually with the X button.`
+    );
+  }
+}
+
+async function removeRecentProject(project: RecentProject) {
+  if (!project.path) return;
+  try {
+    const api = (window as any).electronAPI?.liveplayProjects;
+    const updated = await api?.recentRemove?.(project.path);
+    if (Array.isArray(updated)) recentProjects.value = updated;
+    else await loadRecentProjects();
+  } catch {}
+}
+
 // ---- Project pickers -------------------------------------------------------
 const handleNewProject = () => {
   pickerIntent.value        = 'new';
   pickerMode.value          = 'directory';
   pickerFilter.value        = 'all';
   pickerFilterOptions.value = ['all'];
-  pickerStart.value         = '';
+  pickerStart.value         = recentProjectStartPath();
   showPicker.value          = true;
 };
 
@@ -635,7 +728,7 @@ const handleOpenProject = () => {
   pickerMode.value          = 'file';
   pickerFilter.value        = '.liveplay';
   pickerFilterOptions.value = ['.liveplay', 'all'];
-  pickerStart.value         = '';
+  pickerStart.value         = recentProjectStartPath();
   showPicker.value          = true;
 };
 
@@ -732,9 +825,7 @@ if (import.meta.client && (window as any).electronAPI) {
   object-fit: contain;
 }
 
-.welcome-text {
-  text-align: left;
-}
+.welcome-text { text-align: left; }
 
 .welcome-title {
   font-size: 64px;
@@ -760,48 +851,6 @@ if (import.meta.client && (window as any).electronAPI) {
   font-size: 20px;
   color: var(--color-text-secondary);
   margin: 0;
-}
-
-.welcome-actions {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-md);
-}
-
-.welcome-button {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--spacing-md);
-  padding: var(--spacing-lg) var(--spacing-xl);
-  font-size: 18px;
-  font-weight: 500;
-  background-color: var(--color-surface);
-  border: 2px solid var(--color-border);
-  border-radius: var(--border-radius-lg);
-  transition: all var(--transition-base);
-
-  &:hover {
-    background-color: var(--color-surface-hover);
-    border-color: var(--color-accent);
-    transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-  }
-
-  &.primary {
-    background-color: var(--color-accent);
-    border-color: var(--color-accent);
-    color: white;
-
-    &:hover {
-      background-color: var(--color-accent-hover);
-      border-color: var(--color-accent-hover);
-    }
-  }
-}
-
-.button-icon {
-  font-size: 24px;
 }
 
 .welcome-stage {
@@ -874,9 +923,7 @@ if (import.meta.client && (window as any).electronAPI) {
   color: white;
   border-color: var(--color-accent);
 }
-.welcome-button.primary:hover {
-  filter: brightness(1.08);
-}
+.welcome-button.primary:hover { filter: brightness(1.08); }
 .welcome-button:disabled {
   opacity: 0.5;
   cursor: not-allowed;
@@ -893,9 +940,7 @@ if (import.meta.client && (window as any).electronAPI) {
   flex-direction: column;
   align-items: flex-start;
 }
-.button-label-line {
-  font-weight: 600;
-}
+.button-label-line { font-weight: 600; }
 .button-label-sub {
   font-size: 12px;
   opacity: 0.8;
@@ -1015,6 +1060,10 @@ if (import.meta.client && (window as any).electronAPI) {
 }
 .discovered-remove:hover { color: var(--color-danger, #e5534b); background: var(--color-surface-hover); }
 
+.recent-projects { margin-top: 14px; }
+.recent-project-row .discovered-meta { max-width: 430px; }
+.recent-projects-empty { margin-top: 12px; }
+
 @keyframes lp-spin { to { transform: rotate(360deg); } }
 .spin { display: inline-block; animation: lp-spin 0.85s linear infinite; }
 </style>
@@ -1063,9 +1112,7 @@ if (import.meta.client && (window as any).electronAPI) {
   transition: border-color var(--transition-fast);
 }
 
-.name-dialog__input:focus {
-  border-color: var(--color-accent);
-}
+.name-dialog__input:focus { border-color: var(--color-accent); }
 
 .name-dialog__actions {
   display: flex;

--- a/client/electron/preload.js
+++ b/client/electron/preload.js
@@ -8,6 +8,12 @@ try {
   console.warn('webUtils not available:', e);
 }
 
+function replaceIpcListener(channel, callback) {
+  ipcRenderer.removeAllListeners(channel);
+  ipcRenderer.on(channel, callback);
+  return () => ipcRenderer.removeListener(channel, callback);
+}
+
 contextBridge.exposeInMainWorld('electronAPI', {
   // File dialogs
   selectProjectFolder: () => ipcRenderer.invoke('select-project-folder'),
@@ -81,19 +87,21 @@ contextBridge.exposeInMainWorld('electronAPI', {
       });
   },
 
-  // Menu events
-  onMenuNewProject: (callback) => ipcRenderer.on('menu-new-project', callback),
-  onMenuOpenProject: (callback) => ipcRenderer.on('menu-open-project', callback),
-  onMenuSaveProject: (callback) => ipcRenderer.on('menu-save-project', callback),
-  onMenuExportProject: (callback) => ipcRenderer.on('menu-export-project', callback),
-  onMenuImportProject: (callback) => ipcRenderer.on('menu-import-project', callback),
-  onMenuCloseProject: (callback) => ipcRenderer.on('menu-close-project', callback),
-  onMenuOpenRecentProject: (callback) => ipcRenderer.on('menu-open-recent-project', callback),
-  onMenuOpenProjectFolder: (callback) => ipcRenderer.on('menu-open-project-folder', callback),
-  onMenuToggleDarkMode: (callback) => ipcRenderer.on('menu-toggle-dark-mode', callback),
-  onMenuChangeAccentColor: (callback) => ipcRenderer.on('menu-change-accent-color', callback),
-  onMenuChangeLanguage: (callback) => ipcRenderer.on('menu-change-language', callback),
-  onMenuShowAbout: (callback) => ipcRenderer.on('menu-show-about', callback),
+  // Menu events. These are mounted by Vue components that can be replaced when
+  // projects are opened/closed; keep one live renderer listener per channel so
+  // menu actions do not fire once for every previous component instance.
+  onMenuNewProject: (callback) => replaceIpcListener('menu-new-project', callback),
+  onMenuOpenProject: (callback) => replaceIpcListener('menu-open-project', callback),
+  onMenuSaveProject: (callback) => replaceIpcListener('menu-save-project', callback),
+  onMenuExportProject: (callback) => replaceIpcListener('menu-export-project', callback),
+  onMenuImportProject: (callback) => replaceIpcListener('menu-import-project', callback),
+  onMenuCloseProject: (callback) => replaceIpcListener('menu-close-project', callback),
+  onMenuOpenRecentProject: (callback) => replaceIpcListener('menu-open-recent-project', callback),
+  onMenuOpenProjectFolder: (callback) => replaceIpcListener('menu-open-project-folder', callback),
+  onMenuToggleDarkMode: (callback) => replaceIpcListener('menu-toggle-dark-mode', callback),
+  onMenuChangeAccentColor: (callback) => replaceIpcListener('menu-change-accent-color', callback),
+  onMenuChangeLanguage: (callback) => replaceIpcListener('menu-change-language', callback),
+  onMenuShowAbout: (callback) => replaceIpcListener('menu-show-about', callback),
 
   // External links
   openExternal: (url) => ipcRenderer.invoke('open-external', url),
@@ -120,16 +128,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
   onManualUpdateAvailable: (callback) => ipcRenderer.on('manual-update-available', callback),
 
   // API triggers
-  onTriggerItem: (callback) => ipcRenderer.on('trigger-item', callback),
-  onStopItem: (callback) => ipcRenderer.on('stop-item', callback),
-  onTriggerCartSlot: (callback) => ipcRenderer.on('trigger-cart-slot', callback),
-  onStopAllCues: (callback) => ipcRenderer.on('stop-all-cues', callback),
+  onTriggerItem: (callback) => replaceIpcListener('trigger-item', callback),
+  onStopItem: (callback) => replaceIpcListener('stop-item', callback),
+  onTriggerCartSlot: (callback) => replaceIpcListener('trigger-cart-slot', callback),
+  onStopAllCues: (callback) => replaceIpcListener('stop-all-cues', callback),
 
   // HTTP API — project data sync and PATCH round-trips
   syncProjectData: (data) => ipcRenderer.send('sync-project-data', data),
   sendApiResponse: (data) => ipcRenderer.send('api-response', data),
-  onApiUpdateItem: (callback) => ipcRenderer.on('api-update-item', callback),
-  onApiUpdateCartItem: (callback) => ipcRenderer.on('api-update-cart-item', callback),
+  onApiUpdateItem: (callback) => replaceIpcListener('api-update-item', callback),
+  onApiUpdateCartItem: (callback) => replaceIpcListener('api-update-cart-item', callback),
   
   // File association - opening project files (.liveplay / .lpa).
   // Push: main → renderer for warm-start / macOS open-file events.
@@ -142,8 +150,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   openCartPlayerWindow: (projectFolderPath) => ipcRenderer.invoke('open-cart-player-window', projectFolderPath),
   attachCartPlayerWindow: () => ipcRenderer.send('cart-player-window-attach'),
   getCartWindowProjectData: () => ipcRenderer.invoke('get-cart-window-project-data'),
-  onCartPlayerWindowOpened: (callback) => ipcRenderer.on('cart-player-window-opened', callback),
-  onCartPlayerWindowClosed: (callback) => ipcRenderer.on('cart-player-window-closed', callback),
+  onCartPlayerWindowOpened: (callback) => replaceIpcListener('cart-player-window-opened', callback),
+  onCartPlayerWindowClosed: (callback) => replaceIpcListener('cart-player-window-closed', callback),
   onCartWindowProjectUpdate: (callback) => ipcRenderer.on('cart-window-project-update', callback),
 
   // UI mode ("show mode") sync across windows


### PR DESCRIPTION
## Summary

- Add a recent-projects section to the welcome screen project picker.
- Allow recent projects to be opened directly from the welcome screen.
- Allow recent project entries to be removed manually with the X button.
- Keep failed recent-project entries in the list and show a clearer failure message with the attempted path.
- Default the server-side audio import browser to the current project folder.

## Why

LivePlay projects are often reopened or created repeatedly from the same show folder. Showing recent projects on the welcome screen and starting server-side browsers in the relevant project folder reduces repeated navigation.

Failed recent-project opens should not automatically remove entries, because a project may still exist but be temporarily unavailable, locked, unsynced, or not readable from the currently selected server.

## Implementation notes

- Recent projects use the existing Electron recent-projects API/storage.
- The welcome screen reuses existing localized labels for the recent-projects UI.
- Failed recent-project opens log the attempted path and keep the entry in the list.
- Server-side project pickers start from the most recent project folder.
- The server-side audio import browser starts from the current project folder.
- Native OS audio file dialogs are intentionally unchanged.
- Renderer IPC menu listeners are now replaced per channel to avoid duplicate handlers across project open/close cycles.

## Localization note

This PR reuses existing localized labels for the recent-projects UI. The detailed recent-open failure dialog currently follows the existing WelcomeScreen pattern of hard-coded fallback alerts.

## Test plan

- [x] `git diff --check`
- [x] `npm run build:client`
- [x] `npm run dev`

Manual validation on Windows:

- [x] Started LivePlay with the local server.
- [x] Opened an existing `.liveplay` project.
- [x] Verified the project appears under Recent Projects after returning to the welcome screen or restarting.
- [x] Clicked a valid recent project and verified it opens directly.
- [x] Removed a recent project with the X button and verified only the recent entry is removed, not the project file.
- [x] Temporarily renamed or moved a recent project file, clicked its recent entry, and verified:
  - [x] the entry is not removed automatically,
  - [x] the attempted path is logged,
  - [x] the clearer failure message is shown.
- [x] Restored the file and verified it can be opened again.
- [x] Verified New Project starts the server-side picker in the most recent project folder.
- [x] Verified Open Project Folder starts the server-side picker in the most recent project folder.
- [x] In an open project, opened Audio Import and verified the server-side file browser starts in the project folder.
- [x] Verified the native OS audio file dialog still opens normally.

Not tested:

- [ ] Cross-platform validation outside Windows.
- [ ] Remote-server validation on a second machine.