### PR TITLE
fix: preserve stereo through bussing

### DIFF
--- a/server/include/liveplay/audio/engine.hpp
+++ b/server/include/liveplay/audio/engine.hpp
@@ -130,17 +130,30 @@ struct EngineConfig {
 // ---------------------------------------------------------------------------
 struct ItemRouteEntry {
     std::shared_ptr<PlaybackItem>   item;
-    // For each source channel of the item, a list of (mixer channel ptr, gain).
+    // For each source channel of the item, a list of sends into mixer lanes.
+    // Lanes are concrete here (0..kMixerLanes-1) — kAllMixerLanes routes are
+    // expanded into one send per lane when the snapshot is built.
+    struct Send {
+        std::shared_ptr<MixerChannel> mixer;
+        ChannelIndex                  lane = 0;
+        float                         gain = 1.0f;
+    };
     struct SendList {
-        std::vector<std::pair<std::shared_ptr<MixerChannel>, float>> sends;
+        std::vector<Send> sends;
     };
     std::vector<SendList> per_source_channel;
 };
 
 struct MasterRouteEntry {
     MasterChannelIndex index = kInvalidMasterChannel;
-    // Per master-channel: list of mixer channels feeding it, with gain.
-    std::vector<std::pair<std::shared_ptr<MixerChannel>, float>> sends;
+    // Per master-channel: list of mixer lanes feeding it, with gain. Lanes are
+    // concrete here (kAllMixerLanes expanded at snapshot-build time).
+    struct Send {
+        std::shared_ptr<MixerChannel> mixer;
+        ChannelIndex                  lane = 0;
+        float                         gain = 1.0f;
+    };
+    std::vector<Send> sends;
     // Where this master channel lands on hardware. Empty optional = bus is
     // logically defined but not yet assigned to a hardware output (silent).
     std::optional<MasterDestination> destination;
@@ -209,10 +222,10 @@ public:
     // ---- Sensible-default routing ---------------------------------------
     // Brings the engine into a usable state without explicit routing
     // calls: opens the default device if no device is open, creates a
-    // "Main" mixer if no mixer exists, wires master 0/1 to the default
-    // device hardware channels 0/1, and routes every loaded cue's first
-    // two source channels through Main. Idempotent — safe to call any
-    // number of times.
+    // "Main" mixer if no mixer exists, wires Main lane 0/1 → master 0/1 →
+    // default device hardware channels 0/1, and routes every loaded cue's
+    // source channels through Main (stereo → lanes L/R, mono → both lanes).
+    // Idempotent — safe to call any number of times.
     void ensure_default_routing();
 
     // ---- Mixer channels --------------------------------------------------
@@ -221,10 +234,16 @@ public:
     MixerChannel* find_mixer_channel(const MixerChannelId& id) const;
 
     // ---- Routing matrix --------------------------------------------------
+    // `lane` selects which mixer strip lane the source channel feeds
+    // (0 = L, 1 = R). kAllMixerLanes fans the channel across every lane —
+    // right for mono sources; also the legacy pre-lane behaviour.
+    // Routing the same (source_channel, mixer) pair again replaces the
+    // existing send's gain and lane.
     void route_item_source_to_mixer(const CueId& cue,
                                     ChannelIndex source_channel,
                                     const MixerChannelId& mixer,
-                                    float gain_db = 0.0f);
+                                    float gain_db = 0.0f,
+                                    ChannelIndex lane = kAllMixerLanes);
 
     void unroute_item_source_from_mixer(const CueId& cue,
                                         ChannelIndex source_channel,
@@ -237,9 +256,15 @@ public:
     // device. No-op if the cue has no routes.
     void unroute_item_from_all_mixers(const CueId& cue);
 
+    // `lane` selects which mixer strip lane feeds this master channel
+    // (0 = L, 1 = R). kAllMixerLanes sums every lane into the master —
+    // a mono downmix of the strip; also the legacy pre-lane behaviour.
+    // Routing the same (mixer, master) pair again replaces the existing
+    // send's gain and lane.
     void route_mixer_to_master(const MixerChannelId& mixer,
                                MasterChannelIndex master,
-                               float gain_db = 0.0f);
+                               float gain_db = 0.0f,
+                               ChannelIndex lane = kAllMixerLanes);
 
     void unroute_mixer_from_master(const MixerChannelId& mixer,
                                    MasterChannelIndex master);
@@ -308,15 +333,26 @@ private:
     std::vector<std::unique_ptr<Device>>         devices_;
 
     // Pending route description — the source-of-truth that topology rebuilds from.
+    // Lanes here may be kAllMixerLanes (expanded when the snapshot is built).
     struct PendingRoute {
-        // item-to-mixer: cue → (source_channel → [(mixer, gainLin), ...])
+        // item-to-mixer: cue → (source_channel → [sends])
+        struct ItemMixerSend {
+            MixerChannelId mixer;
+            ChannelIndex   lane = kAllMixerLanes;
+            float          gain_lin = 1.0f;
+        };
         struct ItemSourceRoutes {
-            std::vector<std::vector<std::pair<MixerChannelId, float>>> by_source_channel;
+            std::vector<std::vector<ItemMixerSend>> by_source_channel;
         };
         std::unordered_map<std::string, ItemSourceRoutes> item_sources;
 
-        // mixer-to-master: mixerId → [(master, gainLin), ...]
-        std::unordered_map<std::string, std::vector<std::pair<MasterChannelIndex, float>>> mixer_to_master;
+        // mixer-to-master: mixerId → [sends]
+        struct MasterSend {
+            MasterChannelIndex master = kInvalidMasterChannel;
+            ChannelIndex       lane = kAllMixerLanes;
+            float              gain_lin = 1.0f;
+        };
+        std::unordered_map<std::string, std::vector<MasterSend>> mixer_to_master;
 
         // master-to-device: masterIdx → MasterDestination
         std::vector<std::optional<MasterDestination>> master_destinations;
@@ -344,7 +380,7 @@ private:
     std::atomic<std::uint32_t>       consumption_counter_{0};
 
     // Scratch buffers reused by the render thread (allocated once at start()).
-    std::vector<std::vector<Sample>> mixer_accumulators_;  // [mixer_index][frame]
+    std::vector<std::vector<Sample>> mixer_accumulators_;  // [mixer_index * kMixerLanes + lane][frame]
     std::vector<std::vector<Sample>> master_accumulators_; // [master_index][frame]
     // Per-item per-source-channel deinterleaved buffers. Indexed by item index
     // in the current topology snapshot; reallocated when topology changes.

--- a/server/include/liveplay/audio/mixer_channel.hpp
+++ b/server/include/liveplay/audio/mixer_channel.hpp
@@ -2,8 +2,10 @@
 // liveplay/audio/mixer_channel.hpp
 // ----------------------------------------------------------------------------
 // A virtual mixer strip — Tier 2 of the engine's routing tree. Items send into
-// it; it sums, applies its own gain/fade/mute/solo, then sends to one or more
-// Master output channels.
+// it; it sums per lane (kMixerLanes parallel lanes, stereo L/R), applies its
+// own gain/fade/mute/solo across all lanes, then each lane sends to one or
+// more Master output channels. The lane buffers themselves are owned by the
+// engine; the strip owns control state and per-lane meters.
 //
 // State lives in atomics so the control thread can adjust gain etc. without
 // stalling the render thread. The per-block contribution buffer is owned by
@@ -15,6 +17,7 @@
 #include "liveplay/audio/meter.hpp"
 #include "liveplay/audio/types.hpp"
 
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <string>
@@ -44,14 +47,19 @@ public:
     bool  is_muted() const noexcept           { return muted_.load(std::memory_order_relaxed); }
     bool  is_soloed() const noexcept          { return soloed_.load(std::memory_order_relaxed); }
 
-    // Push a block of mono samples (already mixed contribution from items
-    // routed to this channel) into the meter.
-    void update_meter(const Sample* samples, std::size_t frame_count) noexcept;
+    // Push one lane's block of samples (already mixed contribution from items
+    // routed to this strip) into that lane's meter.
+    void update_meter(ChannelIndex lane,
+                      const Sample* samples, std::size_t frame_count) noexcept;
 
     // Initialise audio-thread state (call from engine setup).
     void configure(SampleRate sample_rate, FrameCount render_block) noexcept;
 
-    MeterSnapshot meter_snapshot() const noexcept { return meter_.snapshot(); }
+    // Combined strip reading: element-wise max across lanes (what a single
+    // strip meter widget should show).
+    MeterSnapshot meter_snapshot() const noexcept;
+    // Per-lane reading (L = 0, R = 1) for stereo strip meters.
+    MeterSnapshot meter_snapshot(ChannelIndex lane) const noexcept;
 
 private:
     MixerChannelId id_;
@@ -72,7 +80,7 @@ private:
     SampleRate  sample_rate_  = kDefaultMixSampleRate;
     FrameCount  render_block_ = kDefaultRenderBlock;
 
-    Meter meter_;
+    std::array<Meter, kMixerLanes> meters_;   // one per strip lane (L/R)
 };
 
 } // namespace liveplay::audio

--- a/server/include/liveplay/audio/types.hpp
+++ b/server/include/liveplay/audio/types.hpp
@@ -29,6 +29,13 @@ inline constexpr SampleRate   kDefaultMixSampleRate  = 48'000;
 inline constexpr FrameCount   kDefaultRenderBlock    = 256;   // ~5.3 ms @ 48k
 inline constexpr ChannelCount kDefaultMasterChannels = 64;    // sparse; usually only a handful are wired
 
+// Mixer strips carry this many parallel audio lanes (stereo: L=0, R=1).
+// Item→mixer and mixer→master sends address a specific lane; kAllMixerLanes
+// fans the send across every lane — used for mono sources (centre image) and
+// as the backwards-compatible default for API callers that predate lanes.
+inline constexpr ChannelCount kMixerLanes    = 2;
+inline constexpr ChannelIndex kAllMixerLanes = static_cast<ChannelIndex>(-1);
+
 // ---------------------------------------------------------------------------
 // Strong-typed identifiers. Implemented as a CRTP-free template so each ID
 // type is distinct in the type system but uses the same machinery.

--- a/server/include/liveplay/core/project_state.hpp
+++ b/server/include/liveplay/core/project_state.hpp
@@ -67,12 +67,18 @@ struct RouteSendV2 {
     audio::ChannelIndex source_channel;
     audio::MixerChannelId destination_mixer;
     float gain_db;
+    // Destination strip lane (0 = L, 1 = R); kAllMixerLanes = every lane.
+    // Documents written before lanes existed load as kAllMixerLanes, which
+    // reproduces the old mono-bus behaviour.
+    audio::ChannelIndex lane = audio::kAllMixerLanes;
 };
 
 struct MixerToMasterV2 {
     audio::MixerChannelId mixer;
     audio::MasterChannelIndex master_channel;
     float gain_db;
+    // Source strip lane feeding the master; kAllMixerLanes = sum of lanes.
+    audio::ChannelIndex lane = audio::kAllMixerLanes;
 };
 
 struct MasterAssignment {

--- a/server/src/audio/engine.cpp
+++ b/server/src/audio/engine.cpp
@@ -143,16 +143,25 @@ void AudioEngine::rebuild_topology_locked() {
         const ChannelCount n_src = item->source_channel_count();
         entry.per_source_channel.resize(n_src);
 
-        // Find sends for this item.
+        // Find sends for this item, expanding kAllMixerLanes into one send
+        // per concrete lane so the render loop never branches on it.
         auto it = pending_.item_sources.find(id_str);
         if (it != pending_.item_sources.end()) {
             const auto& isr = it->second.by_source_channel;
             for (ChannelIndex c = 0; c < n_src; ++c) {
                 if (c >= isr.size()) continue;
-                for (const auto& [mixer_id, gain_lin] : isr[c]) {
-                    auto mit = mixers_.find(mixer_id.value);
+                for (const auto& send : isr[c]) {
+                    auto mit = mixers_.find(send.mixer.value);
                     if (mit == mixers_.end()) continue;
-                    entry.per_source_channel[c].sends.emplace_back(mit->second, gain_lin);
+                    if (send.lane == kAllMixerLanes) {
+                        for (ChannelIndex l = 0; l < kMixerLanes; ++l) {
+                            entry.per_source_channel[c].sends.push_back(
+                                {mit->second, l, send.gain_lin});
+                        }
+                    } else if (send.lane < kMixerLanes) {
+                        entry.per_source_channel[c].sends.push_back(
+                            {mit->second, send.lane, send.gain_lin});
+                    }
                 }
             }
         }
@@ -168,9 +177,17 @@ void AudioEngine::rebuild_topology_locked() {
     for (auto& [mixer_id_str, master_sends] : pending_.mixer_to_master) {
         auto mit = mixers_.find(mixer_id_str);
         if (mit == mixers_.end()) continue;
-        for (auto& [master_idx, gain_lin] : master_sends) {
-            if (master_idx >= cfg_.master_channels) continue;
-            snap->masters[master_idx].sends.emplace_back(mit->second, gain_lin);
+        for (auto& send : master_sends) {
+            if (send.master >= cfg_.master_channels) continue;
+            if (send.lane == kAllMixerLanes) {
+                for (ChannelIndex l = 0; l < kMixerLanes; ++l) {
+                    snap->masters[send.master].sends.push_back(
+                        {mit->second, l, send.gain_lin});
+                }
+            } else if (send.lane < kMixerLanes) {
+                snap->masters[send.master].sends.push_back(
+                    {mit->second, send.lane, send.gain_lin});
+            }
         }
     }
 
@@ -556,15 +573,16 @@ void AudioEngine::ensure_default_routing() {
                 pending_.master_destinations[i] = dest;
             }
         }
-        // Step 4: route Main mixer → master 0 + 1 (mono → both, stereo → L/R).
+        // Step 4: route Main mixer lanes → masters (lane 0 → master 0 = L,
+        // lane 1 → master 1 = R) so the strip's stereo image survives.
         auto& m2m = pending_.mixer_to_master[main_mixer.value];
         bool has_m0 = false, has_m1 = false;
-        for (auto& p : m2m) {
-            if (p.first == 0) has_m0 = true;
-            if (p.first == 1) has_m1 = true;
+        for (auto& s : m2m) {
+            if (s.master == 0) has_m0 = true;
+            if (s.master == 1) has_m1 = true;
         }
-        if (!has_m0) m2m.emplace_back(0, 1.0f);
-        if (!has_m1) m2m.emplace_back(1, 1.0f);
+        if (!has_m0) m2m.push_back({0, 0, 1.0f});
+        if (!has_m1) m2m.push_back({1, 1, 1.0f});
 
         // Step 5: auto-route every loaded cue's source channels → Main, but
         // ONLY for cues that have no routes yet. Cues that were explicitly
@@ -593,7 +611,12 @@ void AudioEngine::ensure_default_routing() {
             }
             if (has_any_existing_route) continue;
             for (ChannelIndex ch = 0; ch < audio_count; ++ch) {
-                srcs[ch].emplace_back(main_mixer, 1.0f);
+                // Mono cues fan out to every lane (centre image); multi-channel
+                // cues map even channels → lane 0 (L), odd → lane 1 (R).
+                const ChannelIndex lane = (audio_count == 1)
+                    ? kAllMixerLanes
+                    : static_cast<ChannelIndex>(ch % kMixerLanes);
+                srcs[ch].push_back({main_mixer, lane, 1.0f});
             }
         }
 
@@ -623,7 +646,7 @@ void AudioEngine::remove_mixer_channel(const MixerChannelId& id) {
     for (auto& [_, item_routes] : pending_.item_sources) {
         for (auto& sends : item_routes.by_source_channel) {
             sends.erase(std::remove_if(sends.begin(), sends.end(),
-                                       [&](auto& p){ return p.first == id; }),
+                                       [&](auto& s){ return s.mixer == id; }),
                         sends.end());
         }
     }
@@ -642,7 +665,8 @@ MixerChannel* AudioEngine::find_mixer_channel(const MixerChannelId& id) const {
 void AudioEngine::route_item_source_to_mixer(const CueId& cue,
                                              ChannelIndex source_channel,
                                              const MixerChannelId& mixer,
-                                             float gain_db) {
+                                             float gain_db,
+                                             ChannelIndex lane) {
     std::lock_guard lock{mutex_};
     auto it = items_.find(cue.value);
     if (it == items_.end()) return;
@@ -651,12 +675,14 @@ void AudioEngine::route_item_source_to_mixer(const CueId& cue,
     auto& routes = pending_.item_sources[cue.value].by_source_channel;
     if (source_channel >= routes.size()) routes.resize(source_channel + 1);
 
+    // One send per (source_channel, mixer) pair — re-routing replaces the
+    // existing send's gain and lane rather than stacking a second feed.
     auto& sends = routes[source_channel];
     auto sit = std::find_if(sends.begin(), sends.end(),
-                            [&](auto& p){ return p.first == mixer; });
+                            [&](auto& s){ return s.mixer == mixer; });
     const float gl = db_to_lin(gain_db);
-    if (sit != sends.end()) sit->second = gl;
-    else sends.emplace_back(mixer, gl);
+    if (sit != sends.end()) { sit->gain_lin = gl; sit->lane = lane; }
+    else sends.push_back({mixer, lane, gl});
 
     rebuild_topology_locked();
 }
@@ -671,7 +697,7 @@ void AudioEngine::unroute_item_source_from_mixer(const CueId& cue,
     if (source_channel >= routes.size()) return;
     auto& sends = routes[source_channel];
     sends.erase(std::remove_if(sends.begin(), sends.end(),
-                               [&](auto& p){ return p.first == mixer; }),
+                               [&](auto& s){ return s.mixer == mixer; }),
                 sends.end());
     rebuild_topology_locked();
 }
@@ -689,16 +715,19 @@ void AudioEngine::unroute_item_from_all_mixers(const CueId& cue) {
 
 void AudioEngine::route_mixer_to_master(const MixerChannelId& mixer,
                                         MasterChannelIndex master,
-                                        float gain_db) {
+                                        float gain_db,
+                                        ChannelIndex lane) {
     if (master >= cfg_.master_channels) return;
     std::lock_guard lock{mutex_};
     if (mixers_.find(mixer.value) == mixers_.end()) return;
+    // One send per (mixer, master) pair — re-routing replaces the existing
+    // send's gain and lane rather than stacking a second feed.
     auto& v = pending_.mixer_to_master[mixer.value];
     auto vit = std::find_if(v.begin(), v.end(),
-                            [&](auto& p){ return p.first == master; });
+                            [&](auto& s){ return s.master == master; });
     const float gl = db_to_lin(gain_db);
-    if (vit != v.end()) vit->second = gl;
-    else v.emplace_back(master, gl);
+    if (vit != v.end()) { vit->gain_lin = gl; vit->lane = lane; }
+    else v.push_back({master, lane, gl});
     rebuild_topology_locked();
 }
 
@@ -709,7 +738,7 @@ void AudioEngine::unroute_mixer_from_master(const MixerChannelId& mixer,
     if (it == pending_.mixer_to_master.end()) return;
     auto& v = it->second;
     v.erase(std::remove_if(v.begin(), v.end(),
-                           [&](auto& p){ return p.first == master; }), v.end());
+                           [&](auto& s){ return s.master == master; }), v.end());
     rebuild_topology_locked();
 }
 
@@ -897,8 +926,11 @@ void AudioEngine::render_one_block(const Topology& topo) {
         for (auto& [_, m] : mixers_) active_mixers.emplace_back(m);
         channel_gains_snapshot = output_channel_gains_;
     }
-    if (mixer_accumulators_.size() < active_mixers.size()) {
-        mixer_accumulators_.resize(active_mixers.size(),
+    // One accumulator per mixer *lane* (stereo strips: L and R stay separate
+    // all the way to the masters).
+    const std::size_t lane_buf_count = active_mixers.size() * kMixerLanes;
+    if (mixer_accumulators_.size() < lane_buf_count) {
+        mixer_accumulators_.resize(lane_buf_count,
                                    std::vector<Sample>(block, 0.0f));
     }
     for (auto& mb : mixer_accumulators_) {
@@ -937,14 +969,14 @@ void AudioEngine::render_one_block(const Topology& topo) {
 
         entry.item->render_block(ptrs.data(), n_src, block);
 
-        // Route each source channel to its destination mixers.
+        // Route each source channel to its destination mixer lanes.
         for (ChannelCount c = 0; c < n_src && c < entry.per_source_channel.size(); ++c) {
-            for (const auto& [mixer_ptr, gain_lin] : entry.per_source_channel[c].sends) {
-                auto mit = mixer_index.find(mixer_ptr->id().value);
+            for (const auto& send : entry.per_source_channel[c].sends) {
+                auto mit = mixer_index.find(send.mixer->id().value);
                 if (mit == mixer_index.end()) continue;
-                Sample* acc = mixer_accumulators_[mit->second].data();
+                Sample* acc = mixer_accumulators_[mit->second * kMixerLanes + send.lane].data();
                 const Sample* src = chbufs[c].data();
-                for (std::size_t s = 0; s < block; ++s) acc[s] += src[s] * gain_lin;
+                for (std::size_t s = 0; s < block; ++s) acc[s] += src[s] * send.gain;
             }
         }
     }
@@ -955,22 +987,26 @@ void AudioEngine::render_one_block(const Topology& topo) {
 
     for (std::size_t i = 0; i < active_mixers.size(); ++i) {
         auto& m = active_mixers[i];
+        // current_gain_linear() advances any active fade by one render block —
+        // call it exactly once per strip, then apply to every lane.
         const float gain_lin = m->current_gain_linear();
         const bool  audible  = !m->is_muted() && (!any_soloed || m->is_soloed());
         const float effective = audible ? gain_lin : 0.0f;
-        Sample* buf = mixer_accumulators_[i].data();
-        for (std::size_t s = 0; s < block; ++s) buf[s] *= effective;
-        m->update_meter(buf, block);
+        for (ChannelIndex lane = 0; lane < kMixerLanes; ++lane) {
+            Sample* buf = mixer_accumulators_[i * kMixerLanes + lane].data();
+            for (std::size_t s = 0; s < block; ++s) buf[s] *= effective;
+            m->update_meter(lane, buf, block);
+        }
     }
 
     // ---- Tier-2 → Tier-3 mix into master accumulators ----
     for (MasterChannelIndex mc = 0; mc < cfg_.master_channels; ++mc) {
         Sample* acc = master_accumulators_[mc].data();
-        for (const auto& [mixer_ptr, gain_lin] : topo.masters[mc].sends) {
-            auto mit = mixer_index.find(mixer_ptr->id().value);
+        for (const auto& send : topo.masters[mc].sends) {
+            auto mit = mixer_index.find(send.mixer->id().value);
             if (mit == mixer_index.end()) continue;
-            const Sample* src = mixer_accumulators_[mit->second].data();
-            for (std::size_t s = 0; s < block; ++s) acc[s] += src[s] * gain_lin;
+            const Sample* src = mixer_accumulators_[mit->second * kMixerLanes + send.lane].data();
+            for (std::size_t s = 0; s < block; ++s) acc[s] += src[s] * send.gain;
         }
     }
 

--- a/server/src/audio/mixer_channel.cpp
+++ b/server/src/audio/mixer_channel.cpp
@@ -15,7 +15,7 @@ MixerChannel::MixerChannel(MixerChannelId id, std::string display_name)
 void MixerChannel::configure(SampleRate sample_rate, FrameCount render_block) noexcept {
     sample_rate_  = sample_rate;
     render_block_ = render_block;
-    meter_.configure(sample_rate);
+    for (auto& m : meters_) m.configure(sample_rate);
 }
 
 void MixerChannel::set_gain_db(float db) noexcept {
@@ -85,8 +85,25 @@ float MixerChannel::current_gain_linear() noexcept {
     return start + (target - start) * curve;
 }
 
-void MixerChannel::update_meter(const Sample* samples, std::size_t frame_count) noexcept {
-    meter_.push_block(samples, frame_count);
+void MixerChannel::update_meter(ChannelIndex lane,
+                                const Sample* samples, std::size_t frame_count) noexcept {
+    if (lane >= meters_.size()) return;
+    meters_[lane].push_block(samples, frame_count);
+}
+
+MeterSnapshot MixerChannel::meter_snapshot() const noexcept {
+    MeterSnapshot out;
+    for (const auto& m : meters_) {
+        const auto s = m.snapshot();
+        out.peak_db = std::max(out.peak_db, s.peak_db);
+        out.rms_db  = std::max(out.rms_db,  s.rms_db);
+    }
+    return out;
+}
+
+MeterSnapshot MixerChannel::meter_snapshot(ChannelIndex lane) const noexcept {
+    if (lane >= meters_.size()) return {};
+    return meters_[lane].snapshot();
 }
 
 } // namespace liveplay::audio

--- a/server/src/core/project_state.cpp
+++ b/server/src/core/project_state.cpp
@@ -358,6 +358,7 @@ void to_json(json& j, const RouteSendV2& r) {
         {"source_channel",    r.source_channel},
         {"destination_mixer", r.destination_mixer.value},
         {"gain_db",           r.gain_db},
+        {"lane",              r.lane},
     };
 }
 
@@ -366,6 +367,7 @@ void to_json(json& j, const MixerToMasterV2& r) {
         {"mixer",           r.mixer.value},
         {"master_channel",  r.master_channel},
         {"gain_db",         r.gain_db},
+        {"lane",            r.lane},
     };
 }
 
@@ -2493,8 +2495,8 @@ ProjectState::ensure_device_routing(const std::string& device_name) {
         "Output: " + device_name);
     engine_.assign_master_to_device(master_l, dev, 0);
     engine_.assign_master_to_device(master_r, dev, 1);
-    engine_.route_mixer_to_master(mixer, master_l);
-    engine_.route_mixer_to_master(mixer, master_r);
+    engine_.route_mixer_to_master(mixer, master_l, 0.0f, 0);   // strip L lane
+    engine_.route_mixer_to_master(mixer, master_r, 0.0f, 1);   // strip R lane
 
     {
         std::lock_guard lock{mutex_};
@@ -2512,6 +2514,11 @@ void ProjectState::route_cue_to_mixer(const audio::CueId& cue,
     auto* pi = engine_.find_cue(cue);
     if (!pi) return;
     const auto src_count = pi->source_channel_count();
+    // The LTC synthetic channel is always the LAST source channel — it must
+    // never feed the audible mixer (it gets its own device routing from
+    // apply_ltc_device_routing()). Only the real audio channels route here.
+    const audio::ChannelCount audio_count =
+        (pi->desc().ltc_enabled && src_count > 0) ? src_count - 1 : src_count;
 
     // Drop ALL prior item-to-mixer routes for this cue — including the engine's
     // auto-created "Main" mixer, which ProjectState does NOT track by id. The
@@ -2522,8 +2529,16 @@ void ProjectState::route_cue_to_mixer(const audio::CueId& cue,
     // apply_ltc_device_routing() call that follows routing in play_item.)
     engine_.unroute_item_from_all_mixers(cue);
 
-    for (audio::ChannelIndex c = 0; c < std::min<audio::ChannelCount>(2, src_count); ++c) {
-        engine_.route_item_source_to_mixer(cue, c, mixer);
+    if (audio_count == 1) {
+        // Mono cue: fan the single channel across both strip lanes (centre).
+        engine_.route_item_source_to_mixer(cue, 0, mixer, 0.0f,
+                                           audio::kAllMixerLanes);
+    } else {
+        // Stereo (or wider): L → lane 0, R → lane 1, preserving the image.
+        for (audio::ChannelIndex c = 0;
+             c < std::min<audio::ChannelCount>(audio::kMixerLanes, audio_count); ++c) {
+            engine_.route_item_source_to_mixer(cue, c, mixer, 0.0f, c);
+        }
     }
 }
 
@@ -2627,8 +2642,8 @@ bool ProjectState::start_preview(const std::string& item_uuid) {
             const auto mixer = engine_.create_mixer_channel("Preview");
             engine_.assign_master_to_device(kPreviewMasterL, dev, 0);
             engine_.assign_master_to_device(kPreviewMasterR, dev, 1);
-            engine_.route_mixer_to_master(mixer, kPreviewMasterL);
-            engine_.route_mixer_to_master(mixer, kPreviewMasterR);
+            engine_.route_mixer_to_master(mixer, kPreviewMasterL, 0.0f, 0);
+            engine_.route_mixer_to_master(mixer, kPreviewMasterR, 0.0f, 1);
             {
                 std::lock_guard lock{mutex_};
                 preview_device_      = dev;
@@ -2648,9 +2663,14 @@ bool ProjectState::start_preview(const std::string& item_uuid) {
 
     auto* pi = engine_.find_cue(cue_id);
     if (pi) {
-        engine_.route_item_source_to_mixer(cue_id, 0, preview_mixer);
         if (pi->source_channel_count() >= 2) {
-            engine_.route_item_source_to_mixer(cue_id, 1, preview_mixer);
+            // Stereo: L → lane 0, R → lane 1.
+            engine_.route_item_source_to_mixer(cue_id, 0, preview_mixer, 0.0f, 0);
+            engine_.route_item_source_to_mixer(cue_id, 1, preview_mixer, 0.0f, 1);
+        } else {
+            // Mono: fan across both lanes.
+            engine_.route_item_source_to_mixer(cue_id, 0, preview_mixer, 0.0f,
+                                               audio::kAllMixerLanes);
         }
         pi->prime(2.0, in_point);
     }
@@ -2979,6 +2999,7 @@ bool ProjectState::load_from_json(const json& doc_in) {
                 r.value("source_channel", (audio::ChannelIndex)0),
                 audio::MixerChannelId{r.value("destination_mixer", std::string{})},
                 r.value("gain_db", 0.0f),
+                r.value("lane", audio::kAllMixerLanes),
             });
         }
     }
@@ -2988,6 +3009,7 @@ bool ProjectState::load_from_json(const json& doc_in) {
                 audio::MixerChannelId{r.value("mixer", std::string{})},
                 r.value("master_channel", (audio::MasterChannelIndex)0),
                 r.value("gain_db", 0.0f),
+                r.value("lane", audio::kAllMixerLanes),
             });
         }
     }
@@ -3100,10 +3122,12 @@ void ProjectState::apply_to_engine_locked() {
     // 3) Re-apply routes.
     for (auto& r : item_routes_) {
         engine_.route_item_source_to_mixer(audio::CueId{}, r.source_channel,
-                                           r.destination_mixer, r.gain_db);
+                                           r.destination_mixer, r.gain_db,
+                                           r.lane);
     }
     for (auto& r : mixer_routes_) {
-        engine_.route_mixer_to_master(r.mixer, r.master_channel, r.gain_db);
+        engine_.route_mixer_to_master(r.mixer, r.master_channel, r.gain_db,
+                                      r.lane);
     }
     for (auto& a : master_assignments_) {
         // If the document didn't specify a device (e.g. upgraded legacy

--- a/server/src/net/control_server.cpp
+++ b/server/src/net/control_server.cpp
@@ -1167,11 +1167,14 @@ void ControlServer::install_routes() {
         ([this](const crow::request& req){
             try {
                 auto j = json::parse(req.body);
+                // "lane": destination strip lane (0 = L, 1 = R). Omitted →
+                // every lane (legacy mono-bus behaviour / mono sources).
                 engine_.route_item_source_to_mixer(
                     audio::CueId{j.at("cue").get<std::string>()},
                     j.value("source_channel", (audio::ChannelIndex)0),
                     audio::MixerChannelId{j.at("mixer").get<std::string>()},
-                    j.value("gain_db", 0.0f));
+                    j.value("gain_db", 0.0f),
+                    j.value("lane", audio::kAllMixerLanes));
                 return json_ok(json({{"ok", true}}));
             } catch (const std::exception& e) { return json_err(400, e.what()); }
         });
@@ -1180,10 +1183,13 @@ void ControlServer::install_routes() {
         ([this](const crow::request& req){
             try {
                 auto j = json::parse(req.body);
+                // "lane": source strip lane feeding this master (0 = L,
+                // 1 = R). Omitted → sum of every lane (mono downmix; legacy).
                 engine_.route_mixer_to_master(
                     audio::MixerChannelId{j.at("mixer").get<std::string>()},
                     j.value("master_channel", (audio::MasterChannelIndex)0),
-                    j.value("gain_db", 0.0f));
+                    j.value("gain_db", 0.0f),
+                    j.value("lane", audio::kAllMixerLanes));
                 return json_ok(json({{"ok", true}}));
             } catch (const std::exception& e) { return json_err(400, e.what()); }
         });


### PR DESCRIPTION
Mixer strips were single mono accumulators: every source channel of a cue summed into one buffer, and that mono sum was then duplicated to both master output channels. All playback was effectively mono.

Mixer strips now carry kMixerLanes (2) parallel lanes:

* Item-to-mixer and mixer-to-master sends address an explicit lane. kAllMixerLanes fans a send across every lane - used for mono sources (centre image) and as the backwards-compatible default for the REST routing endpoints and pre-lane project documents.
* Default routing, per-device override routing, and preview routing all map stereo cues L to lane 0, R to lane 1, and lane 0/1 to master L/R. Mono cues fan to both lanes as before.
* MixerChannel meters each lane separately; the existing single-value meter_snapshot() reports the element-wise max so the WS meters payload and client are unchanged.
* route_cue_to_mixer no longer routes the LTC synthetic channel into the audible mixer (it was included in the first-two-channels loop for mono+LTC cues; LTC routing is handled by apply_ltc_device_routing).

Verified end-to-end against the live engine: a left-only test tone now meters only on master 0, right-only on master 1, mono equally on both; previously all three cases metered identically on both masters.

**NOTE: there is no test suite for engine code. I've verified these changes as much as possible in the absence of a test suite, but please test thoroughly for regressions**