### PR TITLE
feat: external-control surface for Bitfocus Companion support

### DIFF
--- a/server/include/liveplay/core/project_state.hpp
+++ b/server/include/liveplay/core/project_state.hpp
@@ -244,6 +244,24 @@ public:
     // server to seed newly-connected clients with the live override state.
     std::string next_item_override() const;
 
+    // ---- External-control surface (Bitfocus Companion, custom remotes) ----
+    // Compact machine-readable transport summary: project header facts, every
+    // on-air item (name, index path, elapsed/remaining), the effective "Up
+    // Next" target, master gain/limiter state and cart-slot bindings. Built
+    // for polling-free control surfaces — fetch once on connect, then keep it
+    // fresh from the /ws push messages (cue_state, meters, doc_patch).
+    json state_summary() const;
+
+    // GO: trigger whatever is armed as "Up Next". Uses the user-set override
+    // when present (consumed on success), otherwise derives the target from
+    // the currently-playing item's endBehavior — mirroring the client's GO
+    // button. Returns the uuid triggered, or empty if nothing was armed /
+    // derivable / loaded.
+    std::string go();
+
+    // Item uuid bound to a cart slot, or empty if the slot is unbound.
+    std::string cart_slot_item_uuid(int slot) const;
+
     // ---- Per-device routing ---------------------------------------------
     // Ensure a "device mixer" exists for `device_name` (the user-visible
     // name from /api/devices). Opens the audio device if needed, creates a

--- a/server/include/liveplay/net/control_server.hpp
+++ b/server/include/liveplay/net/control_server.hpp
@@ -20,6 +20,12 @@
 //   POST   /api/cues/{id}/fade               — { "in_ms": N, "out_ms": M }
 //   POST   /api/cues/{id}/ltc                — { "enabled":..., "fps":..., "offset_ns":... }
 //   POST   /api/transport/stop_all           — { "fade_ms": 250 }
+//   GET    /api/state/summary                — compact transport state (external control)
+//   POST   /api/transport/go                 — play the armed "Up Next" item
+//   POST   /api/transport/play_index         — { "index": [1, 11] } trigger by index path
+//   POST   /api/transport/cart/{slot}/play   — trigger a cart slot's bound item
+//   GET    /api/master/limiter               — { "enabled": bool }
+//   POST   /api/master/limiter               — { "enabled": bool } (omit = toggle)
 //   POST   /api/routing/item_to_mixer        — { cue, source_channel, mixer, gain_db }
 //   POST   /api/routing/mixer_to_master      — { mixer, master_channel, gain_db }
 //   POST   /api/routing/master_to_device     — { master_channel, device, hw_channel }

--- a/server/src/core/project_state.cpp
+++ b/server/src/core/project_state.cpp
@@ -2429,6 +2429,263 @@ std::string ProjectState::next_item_override() const {
     return next_item_override_;
 }
 
+// ---------------------------------------------------------------------------
+// External-control surface (Bitfocus Companion, custom remotes).
+// ---------------------------------------------------------------------------
+static const char* transport_state_name(audio::TransportState t) {
+    switch (t) {
+        case audio::TransportState::Playing:   return "playing";
+        case audio::TransportState::FadingIn:  return "fading_in";
+        case audio::TransportState::FadingOut: return "fading_out";
+        case audio::TransportState::Paused:    return "paused";
+        default:                               return "stopped";
+    }
+}
+
+json ProjectState::state_summary() const {
+    // Doc-derived facts are snapshotted under mutex_ first; engine transport
+    // is read afterwards (engine calls take their own locks) and the auto
+    // "Up Next" derivation re-acquires mutex_ at the end. Never call into the
+    // engine while holding mutex_ from here — play_item does the same dance.
+    struct ItemFacts {
+        std::string      name;
+        double           duration  = 0.0;  // full-file seconds (0 = unknown)
+        double           in_point  = 0.0;
+        double           out_point = 0.0;  // 0 = play to end
+        std::vector<int> index;            // playlist index path; empty for cart-only items
+    };
+    std::unordered_map<std::string, ItemFacts> facts;
+    // uuid → (cue, duration from decode metadata)
+    std::vector<std::tuple<std::string, audio::CueId, double>> cue_pairs;
+    std::string override_uuid;
+    json project_block;
+    json cart_bindings = json::array();
+
+    {
+        std::lock_guard lock{mutex_};
+
+        const std::size_t item_count =
+            (document_.contains("items") && document_["items"].is_array())
+                ? document_["items"].size() : 0;
+        project_block = json{
+            {"name",           document_.value("name", "")},
+            {"itemCount",      item_count},
+            {"hasOpenProject", item_count > 0 || !project_file_path_.empty()},
+            {"audioLoading",   loading_audio_.load(std::memory_order_acquire)},
+        };
+
+        // Walk the playlist tree recording every item's display facts and its
+        // index path — the same path /api/transport/play_index accepts.
+        std::function<void(const json&, std::vector<int>&)> walk;
+        walk = [&](const json& arr, std::vector<int>& path) {
+            if (!arr.is_array()) return;
+            for (int i = 0; i < static_cast<int>(arr.size()); ++i) {
+                const auto& it = arr[i];
+                if (!it.is_object()) continue;
+                path.push_back(i);
+                const std::string uuid = it.value("uuid", std::string{});
+                if (!uuid.empty()) {
+                    ItemFacts f;
+                    f.name      = it.value("displayName", std::string{});
+                    f.duration  = it.value("duration", 0.0);
+                    f.in_point  = it.value("inPoint",  0.0);
+                    f.out_point = it.value("outPoint", 0.0);
+                    f.index     = path;
+                    facts.emplace(uuid, std::move(f));
+                }
+                if (it.value("type", std::string{}) == "group" &&
+                    it.contains("children")) {
+                    walk(it["children"], path);
+                }
+                path.pop_back();
+            }
+        };
+        std::vector<int> path;
+        if (document_.contains("items")) walk(document_["items"], path);
+
+        // Cart-only items live outside the playlist tree — record their names
+        // so cart bindings resolve, but with no index path.
+        if (document_.contains("cartOnlyItems") && document_["cartOnlyItems"].is_array()) {
+            for (const auto& it : document_["cartOnlyItems"]) {
+                if (!it.is_object()) continue;
+                const std::string uuid = it.value("uuid", std::string{});
+                if (uuid.empty() || facts.count(uuid)) continue;
+                ItemFacts f;
+                f.name      = it.value("displayName", std::string{});
+                f.duration  = it.value("duration", 0.0);
+                f.in_point  = it.value("inPoint",  0.0);
+                f.out_point = it.value("outPoint", 0.0);
+                facts.emplace(uuid, std::move(f));
+            }
+        }
+
+        cue_pairs.reserve(item_uuid_to_cue_.size());
+        for (const auto& [uuid, cue] : item_uuid_to_cue_) {
+            double duration = 0.0;
+            if (auto it = cues_.find(cue.value); it != cues_.end())
+                duration = it->second.duration_seconds;
+            cue_pairs.emplace_back(uuid, cue, duration);
+        }
+
+        override_uuid = next_item_override_;
+
+        if (document_.contains("cartItems") && document_["cartItems"].is_array()) {
+            for (const auto& c : document_["cartItems"]) {
+                if (c.is_object()) cart_bindings.push_back(c);
+            }
+        }
+    }
+
+    // Engine pass: which cues are on air, and where are their playheads.
+    struct OnAir {
+        std::string           uuid;
+        std::string           cue_id;
+        audio::TransportState transport;
+        double                playhead = 0.0;
+        double                duration = 0.0;
+    };
+    std::vector<OnAir> on_air;
+    for (const auto& [uuid, cue, duration] : cue_pairs) {
+        auto* pi = engine_.find_cue(cue);
+        if (!pi) continue;
+        const auto s = pi->stats();
+        if (s.transport == audio::TransportState::Stopped) continue;
+        on_air.push_back(OnAir{uuid, cue.value, s.transport, s.playhead_seconds, duration});
+    }
+    // Document order (index path, lexicographic); cart-only items last.
+    std::sort(on_air.begin(), on_air.end(), [&](const OnAir& a, const OnAir& b) {
+        const auto& ia = facts[a.uuid].index;
+        const auto& ib = facts[b.uuid].index;
+        if (ia.empty() != ib.empty()) return ib.empty();
+        return ia < ib;
+    });
+
+    json playing = json::array();
+    for (const auto& e : on_air) {
+        const auto& f = facts[e.uuid];
+        // Effective bounds honour inPoint / outPoint trims the same way the
+        // client's transport display does.
+        const double duration  = (f.duration > 0.0) ? f.duration : e.duration;
+        const double end       = (f.out_point > f.in_point) ? f.out_point
+                                : (duration > 0.0 ? duration : e.playhead);
+        const double elapsed   = std::max(0.0, e.playhead - f.in_point);
+        const double eff_dur   = std::max(0.0, end - f.in_point);
+        json entry{
+            {"itemUuid",     e.uuid},
+            {"cueId",        e.cue_id},
+            {"name",         f.name},
+            {"transport",    transport_state_name(e.transport)},
+            {"paused",       e.transport == audio::TransportState::Paused},
+            {"playheadSec",  e.playhead},
+            {"elapsedSec",   elapsed},
+            {"durationSec",  eff_dur},
+            {"remainingSec", std::max(0.0, eff_dur - elapsed)},
+        };
+        if (!f.index.empty()) entry["index"] = f.index;
+        playing.push_back(std::move(entry));
+    }
+
+    // Effective "Up Next": user override first, else derived from the
+    // currently-playing item's endBehavior (client GO-button parity).
+    std::string next_uuid   = override_uuid;
+    std::string next_source = next_uuid.empty() ? "" : "override";
+    if (next_uuid.empty() && !on_air.empty()) {
+        std::lock_guard lock{mutex_};
+        for (const auto& e : on_air) {
+            const auto n = resolve_next_item_locked(e.uuid);
+            if (!n.empty()) { next_uuid = n; next_source = "auto"; break; }
+        }
+    }
+    json next = nullptr;
+    if (!next_uuid.empty()) {
+        next = json{{"itemUuid", next_uuid}, {"source", next_source}};
+        if (auto it = facts.find(next_uuid); it != facts.end()) {
+            next["name"] = it->second.name;
+            if (!it->second.index.empty()) next["index"] = it->second.index;
+        }
+    }
+
+    // Cart bindings, decorated with the bound item's name + live state.
+    json cart = json::array();
+    for (const auto& c : cart_bindings) {
+        const int slot = c.value("slot", -1);
+        const std::string uuid = c.value("itemUuid", std::string{});
+        if (slot < 0 || uuid.empty()) continue;
+        json entry{{"slot", slot}, {"itemUuid", uuid}};
+        if (auto it = facts.find(uuid); it != facts.end()) entry["name"] = it->second.name;
+        entry["playing"] = std::any_of(on_air.begin(), on_air.end(),
+                                       [&](const OnAir& e){ return e.uuid == uuid; });
+        cart.push_back(std::move(entry));
+    }
+
+    return json{
+        {"project", std::move(project_block)},
+        {"playing", std::move(playing)},
+        {"next",    std::move(next)},
+        {"master", json{
+            {"gainDb",         engine_.master_gain_db()},
+            {"limiterEnabled", engine_.limiter_enabled()},
+        }},
+        {"cart",    std::move(cart)},
+        {"preview", json{
+            {"active",   !current_preview_item_uuid().empty()},
+            {"itemUuid", current_preview_item_uuid()},
+        }},
+    };
+}
+
+std::string ProjectState::go() {
+    std::string target;
+    {
+        std::lock_guard lock{mutex_};
+        target = next_item_override_;
+    }
+    const bool from_override = !target.empty();
+
+    if (target.empty()) {
+        // No override armed — derive from the currently-playing item's
+        // endBehavior, the same fallback the client's GO button uses.
+        std::vector<std::pair<std::string, audio::CueId>> pairs;
+        {
+            std::lock_guard lock{mutex_};
+            pairs.reserve(item_uuid_to_cue_.size());
+            for (const auto& [u, c] : item_uuid_to_cue_) pairs.emplace_back(u, c);
+        }
+        std::vector<std::string> on_air;
+        for (const auto& [u, c] : pairs) {
+            if (auto* pi = engine_.find_cue(c)) {
+                if (pi->stats().transport != audio::TransportState::Stopped)
+                    on_air.push_back(u);
+            }
+        }
+        {
+            std::lock_guard lock{mutex_};
+            for (const auto& u : on_air) {
+                const auto n = resolve_next_item_locked(u);
+                if (!n.empty()) { target = n; break; }
+            }
+        }
+    }
+
+    if (target.empty()) return {};
+    if (!trigger_item(target)) return {};
+    // Consume the override only after a successful trigger so a GO against a
+    // not-yet-loaded item doesn't silently disarm the operator's choice.
+    if (from_override) set_next_item_override("");
+    return target;
+}
+
+std::string ProjectState::cart_slot_item_uuid(int slot) const {
+    std::lock_guard lock{mutex_};
+    if (!document_.contains("cartItems") || !document_["cartItems"].is_array())
+        return {};
+    for (const auto& c : document_["cartItems"]) {
+        if (c.is_object() && c.value("slot", -1) == slot)
+            return c.value("itemUuid", std::string{});
+    }
+    return {};
+}
+
 // Dispatch by item type: audio → play_item; group → walk startBehavior
 // (play-first plays the first child recursively; play-all triggers every
 // child). Mirrors the client's triggerGroup() so auto-next / Up Next

--- a/server/src/net/control_server.cpp
+++ b/server/src/net/control_server.cpp
@@ -847,6 +847,17 @@ static std::string handle_ws_message(crow::websocket::connection& conn,
                              fade ? std::to_string(*fade) + "ms" : "project default");
             state.stop_all_cues(fade);
         }
+        else if (type == "go") {
+            // Play whatever is armed as "Up Next" (override first, else the
+            // playing item's endBehavior target). Same semantics as
+            // POST /api/transport/go.
+            const auto uuid = state.go();
+            if (uuid.empty()) {
+                Logger::warn("WS go: nothing armed or derivable to play");
+                return json({{"type", "error"}, {"message", "nothing armed to GO to"}}).dump();
+            }
+            Logger::playback("GO: {}", item_playback_info(uuid, state));
+        }
         else if (type == "gain") {
             auto cue = resolve_cue(j);
             if (cue) {
@@ -1106,6 +1117,87 @@ void ControlServer::install_routes() {
             } catch (const std::exception& e) { return json_err(400, e.what()); }
         });
 
+    // ---- External-control surface (Bitfocus Companion, custom remotes) ----
+    // Compact machine-readable transport summary. Control surfaces fetch this
+    // once on connect (and after a project_changed doc_patch), then keep it
+    // fresh from the /ws push stream — no polling.
+    CROW_ROUTE(app, "/api/state/summary").methods(crow::HTTPMethod::Get)
+        ([this] {
+            try {
+                json s = state_.state_summary();
+                s["server"] = json{
+                    {"version", std::string{
+#ifdef LIVEPLAY_SERVER_VERSION
+                        LIVEPLAY_SERVER_VERSION
+#else
+                        "0.0.0"
+#endif
+                    }},
+                    {"meterBroadcastHz", cfg_.meter_broadcast_hz},
+                };
+                return json_ok(s);
+            } catch (const std::exception& e) { return json_err(500, e.what()); }
+            catch (...) { return json_err(500, "internal error"); }
+        });
+
+    // GO — play whatever is armed as "Up Next" (user override first, else the
+    // playing item's endBehavior target). GET is accepted as well as POST so
+    // the URL can be fired from a browser or a plain `curl`.
+    CROW_ROUTE(app, "/api/transport/go")
+        .methods(crow::HTTPMethod::Post, crow::HTTPMethod::Get)
+        ([this](const crow::request& req){
+            Logger::api_request("Client ({}) -> Server ({}) : {} /api/transport/go",
+                                req.remote_ip_address, impl_->server_addr,
+                                crow::method_name(req.method));
+            const std::string uuid = state_.go();
+            if (uuid.empty()) {
+                Logger::warn("GO — nothing armed or derivable to play");
+                return json_err(404, "nothing armed or playing to GO to");
+            }
+            Logger::playback("GO: {}", item_playback_info(uuid, state_));
+            return json_ok(json({{"ok", true}, {"uuid", uuid}}));
+        });
+
+    // First-class body-addressed variant of /api/project/items/by-index/…
+    // Body: { "index": [1, 11] } — an index path descending into groups.
+    CROW_ROUTE(app, "/api/transport/play_index").methods(crow::HTTPMethod::Post)
+        ([this](const crow::request& req){
+            try {
+                auto j = json::parse(req.body);
+                std::vector<int> path;
+                if (j.contains("index") && j["index"].is_array()) {
+                    for (const auto& v : j["index"]) {
+                        if (!v.is_number_integer() || v.get<int>() < 0)
+                            return json_err(400, "index must contain non-negative integers");
+                        path.push_back(v.get<int>());
+                    }
+                }
+                if (path.empty())
+                    return json_err(400, "index must be a non-empty array of child indices");
+                const std::string uuid = state_.item_uuid_by_index(path);
+                if (uuid.empty()) return json_err(404, "no item at that index");
+                Logger::playback("TRIGGER: {}", item_playback_info(uuid, state_));
+                if (!state_.trigger_item(uuid))
+                    return json_err(404, "item not loaded into engine");
+                return json_ok(json({{"ok", true}, {"uuid", uuid}, {"index", path}}));
+            } catch (const std::exception& e) { return json_err(400, e.what()); }
+        });
+
+    // Trigger the item bound to a cart slot. GET accepted for curl/browser.
+    CROW_ROUTE(app, "/api/transport/cart/<int>/play")
+        .methods(crow::HTTPMethod::Post, crow::HTTPMethod::Get)
+        ([this](const crow::request& req, int slot){
+            Logger::api_request("Client ({}) -> Server ({}) : {} /api/transport/cart/{}/play",
+                                req.remote_ip_address, impl_->server_addr,
+                                crow::method_name(req.method), slot);
+            const std::string uuid = state_.cart_slot_item_uuid(slot);
+            if (uuid.empty()) return json_err(404, "cart slot is empty");
+            Logger::playback("CART {}: {}", slot, item_playback_info(uuid, state_));
+            if (!state_.trigger_item(uuid))
+                return json_err(404, "item not loaded into engine");
+            return json_ok(json({{"ok", true}, {"slot", slot}, {"uuid", uuid}}));
+        });
+
     CROW_ROUTE(app, "/api/master/ceiling").methods(crow::HTTPMethod::Post)
         ([this](const crow::request& req){
             try {
@@ -1121,13 +1213,41 @@ void ControlServer::install_routes() {
         ([this](const crow::request& req){
             try {
                 auto j = json::parse(req.body);
-                const float db = j.value("db", 0.0f);
+                // "db" sets an absolute gain; "delta" nudges the current gain
+                // (control-surface increment/decrement without a read-modify-
+                // write race on the caller's side). "db" wins if both present.
+                float db;
+                if (!j.contains("db") && j.contains("delta") && j["delta"].is_number())
+                    db = engine_.master_gain_db() + j["delta"].get<float>();
+                else
+                    db = j.value("db", 0.0f);
                 engine_.set_master_gain_db(db);
                 broadcast_doc_patch(json{
                     {"type", "doc_patch"}, {"op", "master_gain_changed"},
                     {"db", engine_.master_gain_db()},
                 });
                 return json_ok(json({{"ok", true}, {"db", engine_.master_gain_db()}}));
+            } catch (const std::exception& e) { return json_err(400, e.what()); }
+        });
+
+    // Master brickwall limiter enable/bypass. POST body { "enabled": bool };
+    // omitting "enabled" toggles the current state (single-button surfaces).
+    CROW_ROUTE(app, "/api/master/limiter").methods(crow::HTTPMethod::Get)
+        ([this]{ return json_ok(json({{"enabled", engine_.limiter_enabled()}})); });
+    CROW_ROUTE(app, "/api/master/limiter").methods(crow::HTTPMethod::Post)
+        ([this](const crow::request& req){
+            try {
+                auto j = json::parse(req.body.empty() ? std::string{"{}"} : req.body);
+                const bool enabled =
+                    (j.contains("enabled") && j["enabled"].is_boolean())
+                        ? j["enabled"].get<bool>()
+                        : !engine_.limiter_enabled();
+                engine_.set_limiter_enabled(enabled);
+                broadcast_doc_patch(json{
+                    {"type", "doc_patch"}, {"op", "limiter_changed"},
+                    {"enabled", enabled},
+                });
+                return json_ok(json({{"ok", true}, {"enabled", enabled}}));
             } catch (const std::exception& e) { return json_err(400, e.what()); }
         });
 
@@ -2327,6 +2447,34 @@ void ControlServer::install_routes() {
             Logger::api_response("Client ({}) <- Server ({}) : POST /api/project/items/{}/stop OK",
                                  req.remote_ip_address, impl_->server_addr, uuid);
             return json_ok(json({{"ok", true}}));
+        });
+    // Pause / resume hold the playhead without unloading. REST mirror of the
+    // WS "pause"/"resume" messages so stateless control surfaces can use them.
+    CROW_ROUTE(app, "/api/project/items/<string>/pause").methods(crow::HTTPMethod::Post)
+        ([this](const crow::request& req, std::string uuid){
+            Logger::api_request("Client ({}) -> Server ({}) : POST /api/project/items/{}/pause",
+                                req.remote_ip_address, impl_->server_addr, uuid);
+            const auto cue = state_.item_to_cue_id(uuid);
+            if (!cue) return json_err(404, "item not loaded into engine");
+            if (auto* pi = engine_.find_cue(*cue)) {
+                Logger::playback("PAUSE: {}", item_playback_info(uuid, state_));
+                pi->pause();
+                return json_ok(json({{"ok", true}}));
+            }
+            return json_err(404, "item not loaded into engine");
+        });
+    CROW_ROUTE(app, "/api/project/items/<string>/resume").methods(crow::HTTPMethod::Post)
+        ([this](const crow::request& req, std::string uuid){
+            Logger::api_request("Client ({}) -> Server ({}) : POST /api/project/items/{}/resume",
+                                req.remote_ip_address, impl_->server_addr, uuid);
+            const auto cue = state_.item_to_cue_id(uuid);
+            if (!cue) return json_err(404, "item not loaded into engine");
+            if (auto* pi = engine_.find_cue(*cue)) {
+                Logger::playback("RESUME: {}", item_playback_info(uuid, state_));
+                pi->resume();
+                return json_ok(json({{"ok", true}}));
+            }
+            return json_err(404, "item not loaded into engine");
         });
     CROW_ROUTE(app, "/api/project/items/<string>/seek").methods(crow::HTTPMethod::Post)
         ([this](const crow::request& req, std::string uuid){


### PR DESCRIPTION
Server-side half of the Companion integration. This is mostly in line with the companion portion of the LivePlay development plan. The Companion module itself lives in its own repo and consumes this API.

As of now, I am hosting the companion module here: https://github.com/aspinwalld/companion-module-liveplay/releases/latest

Once it has been tested and gets a bit of feedback, I'll submit it for formal PR with BitFocus.