### PR TITLE
Fix/reliability and ltc

### DIFF
--- a/server/include/liveplay/audio/ltc_generator.hpp
+++ b/server/include/liveplay/audio/ltc_generator.hpp
@@ -76,6 +76,15 @@ public:
                    std::chrono::nanoseconds offset = std::chrono::nanoseconds{0},
                    float amplitude_lin = 0.5f);
 
+    // Update ONLY the timecode offset without disturbing the running encoder
+    // state. This is the per-block hot path: unlike configure()/reset() it does
+    // not rewind current_frame_number_ or force polarity_, so biphase-mark
+    // continuity across block boundaries is preserved. render_block() will still
+    // resync naturally on the block where the resulting frame number changes.
+    void set_offset(std::chrono::nanoseconds offset) noexcept {
+        offset_ns_ = offset.count();
+    }
+
     // Reset the encoder to the beginning of the cue (playhead == 0).
     void reset(std::chrono::nanoseconds offset = std::chrono::nanoseconds{0}) noexcept;
 

--- a/server/include/liveplay/core/project_state.hpp
+++ b/server/include/liveplay/core/project_state.hpp
@@ -244,6 +244,24 @@ public:
     // server to seed newly-connected clients with the live override state.
     std::string next_item_override() const;
 
+    // ---- External-control surface (Bitfocus Companion, custom remotes) ----
+    // Compact machine-readable transport summary: project header facts, every
+    // on-air item (name, index path, elapsed/remaining), the effective "Up
+    // Next" target, master gain/limiter state and cart-slot bindings. Built
+    // for polling-free control surfaces — fetch once on connect, then keep it
+    // fresh from the /ws push messages (cue_state, meters, doc_patch).
+    json state_summary() const;
+
+    // GO: trigger whatever is armed as "Up Next". Uses the user-set override
+    // when present (consumed on success), otherwise derives the target from
+    // the currently-playing item's endBehavior — mirroring the client's GO
+    // button. Returns the uuid triggered, or empty if nothing was armed /
+    // derivable / loaded.
+    std::string go();
+
+    // Item uuid bound to a cart slot, or empty if the slot is unbound.
+    std::string cart_slot_item_uuid(int slot) const;
+
     // ---- Per-device routing ---------------------------------------------
     // Ensure a "device mixer" exists for `device_name` (the user-visible
     // name from /api/devices). Opens the audio device if needed, creates a

--- a/server/include/liveplay/crash_handler.hpp
+++ b/server/include/liveplay/crash_handler.hpp
@@ -8,6 +8,7 @@
 // ============================================================================
 #pragma once
 
+#include <cstddef>
 #include <string>
 
 namespace liveplay {
@@ -15,6 +16,26 @@ namespace liveplay {
 // Call once early in main(). Idempotent. `log_dir` is the fallback directory
 // for crash logs when no project dir is known; if empty, cwd is used.
 void install_crash_handlers(const std::string& log_dir = "");
+
+// Configure crash-loop protection. `counter_file` is a path where the
+// consecutive-crash count is persisted across restarts; `consecutive_so_far`
+// is the count read from that file at startup; `max_consecutive` is the number
+// of back-to-back crashes after which the handler stops auto-restarting (so a
+// deterministic crash can't relaunch forever). Call once at startup, after
+// set_crash_exe_info().
+void set_crash_restart_guard(const std::string& counter_file,
+                             int consecutive_so_far,
+                             int max_consecutive);
+
+// Reset the consecutive-crash count to zero (in memory and on disk). Call once
+// the process has been running healthily for a while, and on clean shutdown, so
+// isolated crashes over a long session don't accumulate toward the give-up
+// threshold.
+void reset_crash_restart_guard();
+
+// Delete all but the newest `keep` crash-log files in `dir`. Best-effort;
+// safe to call at startup (never from a signal handler).
+void prune_crash_logs(const std::string& dir, std::size_t keep);
 
 // Tell the crash handler where the server executable lives and what arguments
 // it was started with (so it can relaunch after a crash). Call once after

--- a/server/include/liveplay/logger.hpp
+++ b/server/include/liveplay/logger.hpp
@@ -49,6 +49,15 @@ public:
     // Set the minimum level that will be emitted (default: Info; Debug below).
     static void set_min_level(LogLevel level);
 
+    // Mirror every log line (plain text, ANSI-stripped) to a persistent file so
+    // operators have session history even when stdout isn't captured (e.g. the
+    // server launched by the Electron client). If the file already exceeds
+    // `max_bytes`, it is rotated to "<path>.1" first (single generation). Pass
+    // an empty path to disable file logging. Best-effort: a file-open failure is
+    // logged once and never blocks console logging.
+    static void set_log_file(const std::string& path,
+                             std::size_t max_bytes = 10u * 1024 * 1024);
+
     // -------------------- primary API ---------------------------------------
     template <typename... Args>
     static void debug(std::format_string<Args...> fmt, Args&&... args) {

--- a/server/include/liveplay/net/control_server.hpp
+++ b/server/include/liveplay/net/control_server.hpp
@@ -20,6 +20,12 @@
 //   POST   /api/cues/{id}/fade               — { "in_ms": N, "out_ms": M }
 //   POST   /api/cues/{id}/ltc                — { "enabled":..., "fps":..., "offset_ns":... }
 //   POST   /api/transport/stop_all           — { "fade_ms": 250 }
+//   GET    /api/state/summary                — compact transport state (external control)
+//   POST   /api/transport/go                 — play the armed "Up Next" item
+//   POST   /api/transport/play_index         — { "index": [1, 11] } trigger by index path
+//   POST   /api/transport/cart/{slot}/play   — trigger a cart slot's bound item
+//   GET    /api/master/limiter               — { "enabled": bool }
+//   POST   /api/master/limiter               — { "enabled": bool } (omit = toggle)
 //   POST   /api/routing/item_to_mixer        — { cue, source_channel, mixer, gain_db }
 //   POST   /api/routing/mixer_to_master      — { mixer, master_channel, gain_db }
 //   POST   /api/routing/master_to_device     — { master_channel, device, hw_channel }

--- a/server/src/audio/playback_item.cpp
+++ b/server/src/audio/playback_item.cpp
@@ -472,10 +472,13 @@ std::size_t PlaybackItem::render_block(Sample* const* out_channel_buffers,
             static_cast<long long>(playhead_frames_.load(std::memory_order_relaxed));
         const auto playhead_ns = std::chrono::nanoseconds{
             playhead_frames * 1'000'000'000LL / static_cast<long long>(desc_.mix_sample_rate)};
-        // Refresh offset in case the control thread changed it.
-        ltc_->configure(desc_.mix_sample_rate, desc_.ltc_frame_rate,
-                        std::chrono::nanoseconds{ltc_offset_ns_.load(std::memory_order_acquire)},
-                        /*amplitude*/ 0.5f);
+        // Refresh offset in case the control thread changed it. Use set_offset()
+        // — NOT configure() — so we don't reset the encoder state every block
+        // (that would force polarity back to +1 each block and corrupt the
+        // biphase-mark signal). Sample-rate / frame-rate / enable changes go
+        // through configure() from their dedicated setters instead.
+        ltc_->set_offset(
+            std::chrono::nanoseconds{ltc_offset_ns_.load(std::memory_order_acquire)});
         ltc_->render_block(out_channel_buffers[file_channels_], frame_count, playhead_ns);
     }
 

--- a/server/src/core/project_state.cpp
+++ b/server/src/core/project_state.cpp
@@ -2429,6 +2429,263 @@ std::string ProjectState::next_item_override() const {
     return next_item_override_;
 }
 
+// ---------------------------------------------------------------------------
+// External-control surface (Bitfocus Companion, custom remotes).
+// ---------------------------------------------------------------------------
+static const char* transport_state_name(audio::TransportState t) {
+    switch (t) {
+        case audio::TransportState::Playing:   return "playing";
+        case audio::TransportState::FadingIn:  return "fading_in";
+        case audio::TransportState::FadingOut: return "fading_out";
+        case audio::TransportState::Paused:    return "paused";
+        default:                               return "stopped";
+    }
+}
+
+json ProjectState::state_summary() const {
+    // Doc-derived facts are snapshotted under mutex_ first; engine transport
+    // is read afterwards (engine calls take their own locks) and the auto
+    // "Up Next" derivation re-acquires mutex_ at the end. Never call into the
+    // engine while holding mutex_ from here — play_item does the same dance.
+    struct ItemFacts {
+        std::string      name;
+        double           duration  = 0.0;  // full-file seconds (0 = unknown)
+        double           in_point  = 0.0;
+        double           out_point = 0.0;  // 0 = play to end
+        std::vector<int> index;            // playlist index path; empty for cart-only items
+    };
+    std::unordered_map<std::string, ItemFacts> facts;
+    // uuid → (cue, duration from decode metadata)
+    std::vector<std::tuple<std::string, audio::CueId, double>> cue_pairs;
+    std::string override_uuid;
+    json project_block;
+    json cart_bindings = json::array();
+
+    {
+        std::lock_guard lock{mutex_};
+
+        const std::size_t item_count =
+            (document_.contains("items") && document_["items"].is_array())
+                ? document_["items"].size() : 0;
+        project_block = json{
+            {"name",           document_.value("name", "")},
+            {"itemCount",      item_count},
+            {"hasOpenProject", item_count > 0 || !project_file_path_.empty()},
+            {"audioLoading",   loading_audio_.load(std::memory_order_acquire)},
+        };
+
+        // Walk the playlist tree recording every item's display facts and its
+        // index path — the same path /api/transport/play_index accepts.
+        std::function<void(const json&, std::vector<int>&)> walk;
+        walk = [&](const json& arr, std::vector<int>& path) {
+            if (!arr.is_array()) return;
+            for (int i = 0; i < static_cast<int>(arr.size()); ++i) {
+                const auto& it = arr[i];
+                if (!it.is_object()) continue;
+                path.push_back(i);
+                const std::string uuid = it.value("uuid", std::string{});
+                if (!uuid.empty()) {
+                    ItemFacts f;
+                    f.name      = it.value("displayName", std::string{});
+                    f.duration  = it.value("duration", 0.0);
+                    f.in_point  = it.value("inPoint",  0.0);
+                    f.out_point = it.value("outPoint", 0.0);
+                    f.index     = path;
+                    facts.emplace(uuid, std::move(f));
+                }
+                if (it.value("type", std::string{}) == "group" &&
+                    it.contains("children")) {
+                    walk(it["children"], path);
+                }
+                path.pop_back();
+            }
+        };
+        std::vector<int> path;
+        if (document_.contains("items")) walk(document_["items"], path);
+
+        // Cart-only items live outside the playlist tree — record their names
+        // so cart bindings resolve, but with no index path.
+        if (document_.contains("cartOnlyItems") && document_["cartOnlyItems"].is_array()) {
+            for (const auto& it : document_["cartOnlyItems"]) {
+                if (!it.is_object()) continue;
+                const std::string uuid = it.value("uuid", std::string{});
+                if (uuid.empty() || facts.count(uuid)) continue;
+                ItemFacts f;
+                f.name      = it.value("displayName", std::string{});
+                f.duration  = it.value("duration", 0.0);
+                f.in_point  = it.value("inPoint",  0.0);
+                f.out_point = it.value("outPoint", 0.0);
+                facts.emplace(uuid, std::move(f));
+            }
+        }
+
+        cue_pairs.reserve(item_uuid_to_cue_.size());
+        for (const auto& [uuid, cue] : item_uuid_to_cue_) {
+            double duration = 0.0;
+            if (auto it = cues_.find(cue.value); it != cues_.end())
+                duration = it->second.duration_seconds;
+            cue_pairs.emplace_back(uuid, cue, duration);
+        }
+
+        override_uuid = next_item_override_;
+
+        if (document_.contains("cartItems") && document_["cartItems"].is_array()) {
+            for (const auto& c : document_["cartItems"]) {
+                if (c.is_object()) cart_bindings.push_back(c);
+            }
+        }
+    }
+
+    // Engine pass: which cues are on air, and where are their playheads.
+    struct OnAir {
+        std::string           uuid;
+        std::string           cue_id;
+        audio::TransportState transport;
+        double                playhead = 0.0;
+        double                duration = 0.0;
+    };
+    std::vector<OnAir> on_air;
+    for (const auto& [uuid, cue, duration] : cue_pairs) {
+        auto* pi = engine_.find_cue(cue);
+        if (!pi) continue;
+        const auto s = pi->stats();
+        if (s.transport == audio::TransportState::Stopped) continue;
+        on_air.push_back(OnAir{uuid, cue.value, s.transport, s.playhead_seconds, duration});
+    }
+    // Document order (index path, lexicographic); cart-only items last.
+    std::sort(on_air.begin(), on_air.end(), [&](const OnAir& a, const OnAir& b) {
+        const auto& ia = facts[a.uuid].index;
+        const auto& ib = facts[b.uuid].index;
+        if (ia.empty() != ib.empty()) return ib.empty();
+        return ia < ib;
+    });
+
+    json playing = json::array();
+    for (const auto& e : on_air) {
+        const auto& f = facts[e.uuid];
+        // Effective bounds honour inPoint / outPoint trims the same way the
+        // client's transport display does.
+        const double duration  = (f.duration > 0.0) ? f.duration : e.duration;
+        const double end       = (f.out_point > f.in_point) ? f.out_point
+                                : (duration > 0.0 ? duration : e.playhead);
+        const double elapsed   = std::max(0.0, e.playhead - f.in_point);
+        const double eff_dur   = std::max(0.0, end - f.in_point);
+        json entry{
+            {"itemUuid",     e.uuid},
+            {"cueId",        e.cue_id},
+            {"name",         f.name},
+            {"transport",    transport_state_name(e.transport)},
+            {"paused",       e.transport == audio::TransportState::Paused},
+            {"playheadSec",  e.playhead},
+            {"elapsedSec",   elapsed},
+            {"durationSec",  eff_dur},
+            {"remainingSec", std::max(0.0, eff_dur - elapsed)},
+        };
+        if (!f.index.empty()) entry["index"] = f.index;
+        playing.push_back(std::move(entry));
+    }
+
+    // Effective "Up Next": user override first, else derived from the
+    // currently-playing item's endBehavior (client GO-button parity).
+    std::string next_uuid   = override_uuid;
+    std::string next_source = next_uuid.empty() ? "" : "override";
+    if (next_uuid.empty() && !on_air.empty()) {
+        std::lock_guard lock{mutex_};
+        for (const auto& e : on_air) {
+            const auto n = resolve_next_item_locked(e.uuid);
+            if (!n.empty()) { next_uuid = n; next_source = "auto"; break; }
+        }
+    }
+    json next = nullptr;
+    if (!next_uuid.empty()) {
+        next = json{{"itemUuid", next_uuid}, {"source", next_source}};
+        if (auto it = facts.find(next_uuid); it != facts.end()) {
+            next["name"] = it->second.name;
+            if (!it->second.index.empty()) next["index"] = it->second.index;
+        }
+    }
+
+    // Cart bindings, decorated with the bound item's name + live state.
+    json cart = json::array();
+    for (const auto& c : cart_bindings) {
+        const int slot = c.value("slot", -1);
+        const std::string uuid = c.value("itemUuid", std::string{});
+        if (slot < 0 || uuid.empty()) continue;
+        json entry{{"slot", slot}, {"itemUuid", uuid}};
+        if (auto it = facts.find(uuid); it != facts.end()) entry["name"] = it->second.name;
+        entry["playing"] = std::any_of(on_air.begin(), on_air.end(),
+                                       [&](const OnAir& e){ return e.uuid == uuid; });
+        cart.push_back(std::move(entry));
+    }
+
+    return json{
+        {"project", std::move(project_block)},
+        {"playing", std::move(playing)},
+        {"next",    std::move(next)},
+        {"master", json{
+            {"gainDb",         engine_.master_gain_db()},
+            {"limiterEnabled", engine_.limiter_enabled()},
+        }},
+        {"cart",    std::move(cart)},
+        {"preview", json{
+            {"active",   !current_preview_item_uuid().empty()},
+            {"itemUuid", current_preview_item_uuid()},
+        }},
+    };
+}
+
+std::string ProjectState::go() {
+    std::string target;
+    {
+        std::lock_guard lock{mutex_};
+        target = next_item_override_;
+    }
+    const bool from_override = !target.empty();
+
+    if (target.empty()) {
+        // No override armed — derive from the currently-playing item's
+        // endBehavior, the same fallback the client's GO button uses.
+        std::vector<std::pair<std::string, audio::CueId>> pairs;
+        {
+            std::lock_guard lock{mutex_};
+            pairs.reserve(item_uuid_to_cue_.size());
+            for (const auto& [u, c] : item_uuid_to_cue_) pairs.emplace_back(u, c);
+        }
+        std::vector<std::string> on_air;
+        for (const auto& [u, c] : pairs) {
+            if (auto* pi = engine_.find_cue(c)) {
+                if (pi->stats().transport != audio::TransportState::Stopped)
+                    on_air.push_back(u);
+            }
+        }
+        {
+            std::lock_guard lock{mutex_};
+            for (const auto& u : on_air) {
+                const auto n = resolve_next_item_locked(u);
+                if (!n.empty()) { target = n; break; }
+            }
+        }
+    }
+
+    if (target.empty()) return {};
+    if (!trigger_item(target)) return {};
+    // Consume the override only after a successful trigger so a GO against a
+    // not-yet-loaded item doesn't silently disarm the operator's choice.
+    if (from_override) set_next_item_override("");
+    return target;
+}
+
+std::string ProjectState::cart_slot_item_uuid(int slot) const {
+    std::lock_guard lock{mutex_};
+    if (!document_.contains("cartItems") || !document_["cartItems"].is_array())
+        return {};
+    for (const auto& c : document_["cartItems"]) {
+        if (c.is_object() && c.value("slot", -1) == slot)
+            return c.value("itemUuid", std::string{});
+    }
+    return {};
+}
+
 // Dispatch by item type: audio → play_item; group → walk startBehavior
 // (play-first plays the first child recursively; play-all triggers every
 // child). Mirrors the client's triggerGroup() so auto-next / Up Next

--- a/server/src/crash_handler.cpp
+++ b/server/src/crash_handler.cpp
@@ -1,9 +1,27 @@
 // ============================================================================
 // crash_handler.cpp — see crash_handler.hpp.
+// ----------------------------------------------------------------------------
+// Two crash-emit paths:
+//   * emit_crash_report()      — rich report (session history, symbolised
+//                                stack). Used from contexts where it is safe to
+//                                allocate / lock / touch the filesystem:
+//                                Windows SEH + CRT handlers, and std::terminate.
+//   * async_signal_crash()     — POSIX-only, async-signal-SAFE path used from
+//                                the fatal-signal handler (SIGSEGV/ABRT/…). Uses
+//                                only write()/open()/backtrace_symbols_fd()/fork/
+//                                execve, never malloc / mutex / iostream, so it
+//                                can't deadlock on a crash that happened while
+//                                the faulting thread held the malloc arena lock.
+//
+// Both paths share a persisted consecutive-crash counter so a deterministic
+// crash can't relaunch the server forever (crash-loop protection), and both
+// read crash-resume state from a lock-free double buffer that is never observed
+// half-written.
 // ============================================================================
 #include "liveplay/crash_handler.hpp"
 #include "liveplay/logger.hpp"
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <csignal>
@@ -32,6 +50,8 @@
 #    include <execinfo.h>
 #    define LIVEPLAY_HAVE_EXECINFO 1
 #  endif
+#  include <cerrno>
+#  include <fcntl.h>
 #  include <unistd.h>
 #  include <sys/types.h>
 #  include <sys/wait.h>
@@ -52,17 +72,43 @@ constexpr std::size_t kPathBuf = 4096;
 constexpr std::size_t kArgBuf  = 8192;
 constexpr std::size_t kUuidBuf = 256;
 
-char g_exe_path[kPathBuf]           = {};
-char g_restart_args[kArgBuf]        = {};
-char g_project_dir[kPathBuf]        = {};
-char g_resume_project_file[kPathBuf]= {};
-char g_resume_item_uuid[kUuidBuf]   = {};
-// Plain double is fine here; worst case: a torn read gives a slightly wrong
-// seek position — acceptable in a crash-resume scenario.
-double g_resume_position_sec        = 0.0;
+char g_exe_path[kPathBuf]     = {};
+char g_restart_args[kArgBuf]  = {};
+char g_project_dir[kPathBuf]  = {};
+
+// Pre-resolved + pre-created crash-log directory. Refreshed in safe context
+// (install / set_crash_project_dir) so the signal handler never has to call
+// create_directories(). Empty until first refresh.
+char g_crash_log_dir_buf[kPathBuf] = {};
+
+// ---- Crash-loop protection -------------------------------------------------
+char             g_counter_file[kPathBuf] = {};
+std::atomic<int> g_crash_count{0};       // consecutive crashes so far
+std::atomic<int> g_max_consecutive{0};   // 0 = guard disabled (always restart)
+
+// ---- Crash-resume state (lock-free double buffer) --------------------------
+// The writer fills the inactive buffer completely, then atomically flips the
+// active index. A reader (the crash handler) only ever reads the active index,
+// which always points at a fully-written record — even if the crashing thread
+// was interrupted mid-write, it was writing the *inactive* buffer.
+struct ResumeState {
+    char   project_file[kPathBuf] = {};
+    char   item_uuid[kUuidBuf]    = {};
+    double position_sec           = 0.0;
+};
+ResumeState      g_resume[2];
+std::atomic<int> g_resume_active{-1};   // -1 = no record yet
+
+long long current_pid() {
+#if defined(_WIN32)
+    return static_cast<long long>(GetCurrentProcessId());
+#else
+    return static_cast<long long>(::getpid());
+#endif
+}
 
 // ---------------------------------------------------------------------------
-// Helpers
+// Helpers (safe context)
 // ---------------------------------------------------------------------------
 std::string timestamp_for_filename() {
     using clock = std::chrono::system_clock;
@@ -74,20 +120,21 @@ std::string timestamp_for_filename() {
     localtime_r(&now, &tm);
 #endif
     char buf[32];
-    // Format: YYYY_MM_DD-HHMM  (as requested)
-    std::snprintf(buf, sizeof(buf), "%04d_%02d_%02d-%02d%02d",
+    // Seconds resolution + PID keep filenames unique across a fast crash loop
+    // (minute resolution + O_TRUNC used to overwrite prior logs).
+    std::snprintf(buf, sizeof(buf), "%04d_%02d_%02d-%02d%02d%02d",
                   tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
-                  tm.tm_hour, tm.tm_min);
+                  tm.tm_hour, tm.tm_min, tm.tm_sec);
     return std::string{buf};
 }
 
-std::filesystem::path resolve_crash_log_path() {
+// Recompute + create the crash-log directory into g_crash_log_dir_buf. Safe
+// context only (allocates / touches the filesystem).
+void refresh_log_dir() {
     namespace fs = std::filesystem;
     std::error_code ec;
-
     fs::path dir;
     if (g_project_dir[0] != '\0') {
-        // Preferred: <project_dir>/logs/
         dir = fs::path{g_project_dir} / "logs";
     } else if (!g_crash_log_dir.empty()) {
         dir = g_crash_log_dir;
@@ -96,7 +143,18 @@ std::filesystem::path resolve_crash_log_path() {
         if (ec) dir = ".";
     }
     fs::create_directories(dir, ec);
-    return dir / ("liveplay-crash-" + timestamp_for_filename() + ".log");
+    const std::string s = dir.string();
+    std::strncpy(g_crash_log_dir_buf, s.c_str(), kPathBuf - 1);
+    g_crash_log_dir_buf[kPathBuf - 1] = '\0';
+}
+
+std::filesystem::path resolve_crash_log_path() {
+    namespace fs = std::filesystem;
+    fs::path dir = g_crash_log_dir_buf[0] ? fs::path{g_crash_log_dir_buf} : fs::path{"."};
+    std::error_code ec;
+    fs::create_directories(dir, ec);
+    return dir / ("liveplay-crash-" + timestamp_for_filename() + "-" +
+                  std::to_string(current_pid()) + ".log");
 }
 
 // Minimal JSON string escaper — safe to call from the crash handler.
@@ -112,6 +170,19 @@ std::string json_escape(const char* s) {
         }
     }
     return out;
+}
+
+// Increment the persisted consecutive-crash counter and report whether the
+// server should still auto-restart. Safe context (uses ofstream).
+bool bump_counter_and_should_restart() {
+    const int new_count = g_crash_count.load(std::memory_order_acquire) + 1;
+    g_crash_count.store(new_count, std::memory_order_release);
+    if (g_counter_file[0] != '\0') {
+        std::ofstream cf{g_counter_file, std::ios::binary | std::ios::trunc};
+        if (cf) cf << new_count;
+    }
+    const int maxc = g_max_consecutive.load(std::memory_order_acquire);
+    return !(maxc > 0 && new_count > maxc);
 }
 
 // ---------------------------------------------------------------------------
@@ -216,14 +287,19 @@ std::string format_stack_trace_posix() {
 #endif
 
 // ---------------------------------------------------------------------------
-// Core: write crash log + console output + restart after 5 s.
+// Rich crash report — SAFE contexts only (Windows SEH/CRT, std::terminate).
 // ---------------------------------------------------------------------------
 void emit_crash_report(const std::string& reason, const std::string& trace) {
+    const bool will_restart = bump_counter_and_should_restart();
+
     // 1. Console output — visible to the operator while the window is up.
     try {
         Logger::error("==================== SERVER CRASH ====================");
         Logger::error("Reason : {}", reason);
-        Logger::error("Restart: server will relaunch in 5 seconds.");
+        if (will_restart)
+            Logger::error("Restart: server will relaunch in 5 seconds.");
+        else
+            Logger::error("Restart: DISABLED — too many consecutive crashes; not relaunching.");
         Logger::error("Log    : see liveplay-crash-*.log in the project /logs/ folder.");
         Logger::error("Stack trace:");
         std::istringstream is{trace};
@@ -242,6 +318,7 @@ void emit_crash_report(const std::string& reason, const std::string& trace) {
             f << "LivePlay Server — Crash Report\n"
               << "================================\n"
               << "Time   : " << timestamp_for_filename() << "\n"
+              << "PID    : " << current_pid() << "\n"
               << "Reason : " << reason << "\n\n"
               << "Stack trace:\n" << trace << "\n"
               << "================================\n"
@@ -254,30 +331,30 @@ void emit_crash_report(const std::string& reason, const std::string& trace) {
 
     // 3. Persist resume state so the new instance can reopen the project and
     //    resume playback from approximately where it stopped.
-    if (g_exe_path[0] != '\0' && g_resume_project_file[0] != '\0') {
+    const int ri = g_resume_active.load(std::memory_order_acquire);
+    if (g_exe_path[0] != '\0' && ri >= 0 && g_resume[ri].project_file[0] != '\0') {
         try {
             namespace fs = std::filesystem;
-
-            // Store next to the exe so the new instance finds it at startup.
             const fs::path resume_path =
                 fs::path{g_exe_path}.parent_path() / ".crash-resume.json";
             std::ofstream rf{resume_path, std::ios::binary | std::ios::trunc};
             if (rf) {
                 char pos_buf[64];
-                std::snprintf(pos_buf, sizeof(pos_buf), "%.3f", g_resume_position_sec);
+                std::snprintf(pos_buf, sizeof(pos_buf), "%.3f", g_resume[ri].position_sec);
                 rf << "{\n"
-                   << "  \"projectFile\": \""  << json_escape(g_resume_project_file) << "\",\n"
-                   << "  \"itemUuid\": \""      << json_escape(g_resume_item_uuid)    << "\",\n"
-                   << "  \"positionSec\": "     << pos_buf                            << "\n"
+                   << "  \"projectFile\": \""  << json_escape(g_resume[ri].project_file) << "\",\n"
+                   << "  \"itemUuid\": \""      << json_escape(g_resume[ri].item_uuid)    << "\",\n"
+                   << "  \"positionSec\": "     << pos_buf                                << "\n"
                    << "}\n";
             }
         } catch (...) {}
     }
 
+    if (!will_restart) return;
+
     // 4. Relaunch the server, then exit so the OS releases our listening port.
-    //    Rather than sleeping here (which would hold the port for 5 s and race
-    //    the new instance for it), we spawn immediately and pass --start-delay-ms
-    //    so the *new* instance waits before binding — by which point we're gone.
+    //    We spawn immediately and pass --start-delay-ms so the *new* instance
+    //    waits before binding — by which point we're gone.
 #if defined(_WIN32)
     if (g_exe_path[0] != '\0') {
         std::string cmd = std::string{"\""} + g_exe_path + "\"";
@@ -297,14 +374,11 @@ void emit_crash_report(const std::string& reason, const std::string& trace) {
         if (pi.hThread)  CloseHandle(pi.hThread);
     }
 #else
-    // Fork a child that sleeps then execs the server; the crashing parent exits.
     if (g_exe_path[0] != '\0') {
         const pid_t pid = ::fork();
         if (pid == 0) {
-            // Child: sleep 5 s then exec the original binary.
             ::sleep(5);
             if (g_restart_args[0] != '\0') {
-                // Use sh to re-parse the arg string.
                 std::string cmd = std::string{g_exe_path} + " " + g_restart_args;
                 ::execl("/bin/sh", "sh", "-c", cmd.c_str(), nullptr);
             } else {
@@ -312,10 +386,163 @@ void emit_crash_report(const std::string& reason, const std::string& trace) {
             }
             ::_exit(1);
         }
-        // Parent falls through and exits normally below.
     }
 #endif
 }
+
+// ---------------------------------------------------------------------------
+// Async-signal-safe crash emit — POSIX fatal-signal path ONLY.
+// ---------------------------------------------------------------------------
+#if !defined(_WIN32)
+// Small async-signal-safe output primitives (no malloc / stdio / locale).
+struct AsBuf { char* p; std::size_t cap; std::size_t len; };
+
+void as_append(AsBuf& b, const char* s) {
+    while (*s && b.len + 1 < b.cap) b.p[b.len++] = *s++;
+    b.p[b.len] = '\0';
+}
+void as_append_ll(AsBuf& b, long long v) {
+    char t[32]; int i = static_cast<int>(sizeof(t));
+    const bool neg = v < 0;
+    unsigned long long u = neg ? (0ULL - static_cast<unsigned long long>(v))
+                               : static_cast<unsigned long long>(v);
+    if (u == 0) t[--i] = '0';
+    while (u) { t[--i] = static_cast<char>('0' + u % 10); u /= 10; }
+    if (neg) t[--i] = '-';
+    for (; i < static_cast<int>(sizeof(t)) && b.len + 1 < b.cap; ++i) b.p[b.len++] = t[i];
+    b.p[b.len] = '\0';
+}
+void as_write(int fd, const char* s, std::size_t n) {
+    while (n > 0) {
+        const ssize_t w = ::write(fd, s, n);
+        if (w <= 0) { if (errno == EINTR) continue; break; }
+        s += w; n -= static_cast<std::size_t>(w);
+    }
+}
+void as_write_str(int fd, const char* s) {
+    std::size_t n = 0; while (s[n]) ++n; as_write(fd, s, n);
+}
+void as_write_ll(int fd, long long v) {
+    char t[32]; AsBuf b{t, sizeof(t), 0}; t[0] = '\0';
+    as_append_ll(b, v); as_write(fd, t, b.len);
+}
+void as_write_escaped(int fd, const char* s) {
+    for (; *s; ++s) {
+        switch (*s) {
+            case '"':  as_write(fd, "\\\"", 2); break;
+            case '\\': as_write(fd, "\\\\", 2); break;
+            case '\n': as_write(fd, "\\n", 2);  break;
+            case '\r': as_write(fd, "\\r", 2);  break;
+            default:   as_write(fd, s, 1);      break;
+        }
+    }
+}
+void as_write_fixed3(int fd, double v) {
+    bool neg = v < 0; if (neg) v = -v;
+    long long whole = static_cast<long long>(v);
+    long long frac  = static_cast<long long>((v - static_cast<double>(whole)) * 1000.0 + 0.5);
+    if (frac >= 1000) { whole += 1; frac -= 1000; }
+    if (neg) as_write(fd, "-", 1);
+    as_write_ll(fd, whole);
+    as_write(fd, ".", 1);
+    char f[3] = { static_cast<char>('0' + (frac / 100) % 10),
+                  static_cast<char>('0' + (frac / 10) % 10),
+                  static_cast<char>('0' + frac % 10) };
+    as_write(fd, f, 3);
+}
+
+void async_signal_crash(const char* reason) {
+    const long long epoch = static_cast<long long>(::time(nullptr));
+    const long long pid   = static_cast<long long>(::getpid());
+
+    // Build "<dir>/liveplay-crash-<epoch>-<pid>.log" without allocating.
+    char path[kPathBuf]; AsBuf pb{path, sizeof(path), 0}; path[0] = '\0';
+    if (g_crash_log_dir_buf[0]) { as_append(pb, g_crash_log_dir_buf); as_append(pb, "/"); }
+    as_append(pb, "liveplay-crash-");
+    as_append_ll(pb, epoch); as_append(pb, "-"); as_append_ll(pb, pid);
+    as_append(pb, ".log");
+
+    const int fd = ::open(path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd >= 0) {
+        as_write_str(fd, "LivePlay Server — Crash Report\n"
+                         "================================\n"
+                         "Time (epoch): ");
+        as_write_ll(fd, epoch);
+        as_write_str(fd, "\nPID    : "); as_write_ll(fd, pid);
+        as_write_str(fd, "\nReason : "); as_write_str(fd, reason);
+        as_write_str(fd, "\n\nStack trace:\n");
+#if defined(LIVEPLAY_HAVE_EXECINFO)
+        void* bt[64];
+        const int n = backtrace(bt, 64);
+        backtrace_symbols_fd(bt, n, fd);   // async-signal-safe (no malloc)
+#else
+        as_write_str(fd, "(stack trace unavailable: execinfo.h not present)\n");
+#endif
+        as_write_str(fd, "\n(session history is in the rolling server log, if enabled)\n");
+        ::close(fd);
+    }
+
+    // Visible operator signal on stderr.
+    as_write_str(STDERR_FILENO, "\n==================== SERVER CRASH ====================\n");
+    as_write_str(STDERR_FILENO, reason);
+    as_write_str(STDERR_FILENO, "\nCrash log: "); as_write_str(STDERR_FILENO, path);
+    as_write_str(STDERR_FILENO, "\n");
+
+    // Persist crash-resume state from the double buffer (always complete).
+    const int ri = g_resume_active.load(std::memory_order_acquire);
+    if (g_exe_path[0] && ri >= 0 && g_resume[ri].project_file[0]) {
+        char rpath[kPathBuf]; AsBuf rb{rpath, sizeof(rpath), 0}; rpath[0] = '\0';
+        as_append(rb, g_exe_path);
+        // Trim to the executable's parent directory.
+        std::size_t cut = rb.len;
+        while (cut > 0 && rpath[cut - 1] != '/') --cut;
+        rb.len = cut; rpath[rb.len] = '\0';
+        as_append(rb, ".crash-resume.json");
+        const int rfd = ::open(rpath, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+        if (rfd >= 0) {
+            as_write_str(rfd, "{\n  \"projectFile\": \"");
+            as_write_escaped(rfd, g_resume[ri].project_file);
+            as_write_str(rfd, "\",\n  \"itemUuid\": \"");
+            as_write_escaped(rfd, g_resume[ri].item_uuid);
+            as_write_str(rfd, "\",\n  \"positionSec\": ");
+            as_write_fixed3(rfd, g_resume[ri].position_sec);
+            as_write_str(rfd, "\n}\n");
+            ::close(rfd);
+        }
+    }
+
+    // Crash-loop guard: persist the incremented counter and decide.
+    const int new_count = g_crash_count.load(std::memory_order_acquire) + 1;
+    if (g_counter_file[0]) {
+        const int cfd = ::open(g_counter_file, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+        if (cfd >= 0) { as_write_ll(cfd, new_count); ::close(cfd); }
+    }
+    const int maxc = g_max_consecutive.load(std::memory_order_acquire);
+    if (maxc > 0 && new_count > maxc) {
+        as_write_str(STDERR_FILENO,
+                     "Auto-restart DISABLED — too many consecutive crashes.\n");
+        return;
+    }
+
+    // Relaunch: fork a child that waits then re-execs; the parent returns and
+    // the caller re-raises the signal so the OS frees our listening port.
+    if (g_exe_path[0]) {
+        const pid_t child = ::fork();
+        if (child == 0) {
+            ::sleep(5);
+            if (g_restart_args[0]) {
+                char cmd[kArgBuf + kPathBuf + 8];
+                AsBuf cb{cmd, sizeof(cmd), 0}; cmd[0] = '\0';
+                as_append(cb, g_exe_path); as_append(cb, " "); as_append(cb, g_restart_args);
+                ::execl("/bin/sh", "sh", "-c", cmd, static_cast<char*>(nullptr));
+            } else {
+                ::execl(g_exe_path, g_exe_path, static_cast<char*>(nullptr));
+            }
+            ::_exit(127);
+        }
+    }
+}
+#endif // !_WIN32
 
 // ---------------------------------------------------------------------------
 // Platform handlers
@@ -404,7 +631,8 @@ extern "C" void posix_fatal_signal(int sig) {
 #  endif
         default: break;
     }
-    emit_crash_report(name, format_stack_trace_posix());
+    // Async-signal-safe path: no malloc / mutex / iostream / filesystem.
+    async_signal_crash(name);
     std::signal(sig, SIG_DFL);
     std::raise(sig);
 }
@@ -418,6 +646,7 @@ extern "C" void posix_fatal_signal(int sig) {
 void install_crash_handlers(const std::string& log_dir) {
     std::call_once(g_install_flag, [&]{
         g_crash_log_dir = log_dir;
+        refresh_log_dir();
 
         std::set_terminate(&terminate_handler);
 
@@ -456,14 +685,68 @@ void set_crash_exe_info(const std::string& exe_path,
 
 void set_crash_project_dir(const std::string& project_dir) {
     std::strncpy(g_project_dir, project_dir.c_str(), kPathBuf - 1);
+    g_project_dir[kPathBuf - 1] = '\0';
+    refresh_log_dir();
 }
 
 void update_crash_resume_state(const std::string& project_file,
                                 const std::string& playing_item_uuid,
                                 double             position_sec) {
-    std::strncpy(g_resume_project_file, project_file.c_str(),        kPathBuf - 1);
-    std::strncpy(g_resume_item_uuid,    playing_item_uuid.c_str(),   kUuidBuf - 1);
-    g_resume_position_sec = position_sec;
+    // Fill the inactive buffer, then publish it by flipping the active index.
+    const int active = g_resume_active.load(std::memory_order_acquire);
+    const int next   = (active == 0) ? 1 : 0;   // -1 or 1 → 0; 0 → 1
+    ResumeState& b = g_resume[next];
+    std::strncpy(b.project_file, project_file.c_str(),      kPathBuf - 1);
+    b.project_file[kPathBuf - 1] = '\0';
+    std::strncpy(b.item_uuid,    playing_item_uuid.c_str(), kUuidBuf - 1);
+    b.item_uuid[kUuidBuf - 1] = '\0';
+    b.position_sec = position_sec;
+    g_resume_active.store(next, std::memory_order_release);
+}
+
+void set_crash_restart_guard(const std::string& counter_file,
+                             int consecutive_so_far,
+                             int max_consecutive) {
+    std::strncpy(g_counter_file, counter_file.c_str(), kPathBuf - 1);
+    g_counter_file[kPathBuf - 1] = '\0';
+    g_crash_count.store(consecutive_so_far < 0 ? 0 : consecutive_so_far,
+                        std::memory_order_release);
+    g_max_consecutive.store(max_consecutive, std::memory_order_release);
+}
+
+void reset_crash_restart_guard() {
+    g_crash_count.store(0, std::memory_order_release);
+    if (g_counter_file[0] != '\0') {
+        std::ofstream cf{g_counter_file, std::ios::binary | std::ios::trunc};
+        if (cf) cf << 0;
+    }
+}
+
+void prune_crash_logs(const std::string& dir, std::size_t keep) {
+    namespace fs = std::filesystem;
+    try {
+        std::error_code ec;
+        if (!fs::is_directory(dir, ec)) return;
+        std::vector<fs::path> logs;
+        for (const auto& entry : fs::directory_iterator(dir, ec)) {
+            if (ec) break;
+            const auto& p = entry.path();
+            const std::string fn = p.filename().string();
+            if (fn.rfind("liveplay-crash-", 0) == 0 && p.extension() == ".log")
+                logs.push_back(p);
+        }
+        if (logs.size() <= keep) return;
+        std::sort(logs.begin(), logs.end(), [](const fs::path& a, const fs::path& b) {
+            std::error_code e1, e2;
+            return fs::last_write_time(a, e1) < fs::last_write_time(b, e2);
+        });
+        for (std::size_t i = 0; i + keep < logs.size(); ++i) {
+            std::error_code rec;
+            fs::remove(logs[i], rec);
+        }
+    } catch (...) {
+        // Best-effort pruning — never let it affect startup.
+    }
 }
 
 } // namespace liveplay

--- a/server/src/logger.cpp
+++ b/server/src/logger.cpp
@@ -7,6 +7,8 @@
 #include <chrono>
 #include <cstdio>
 #include <ctime>
+#include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <mutex>
 #include <string>
@@ -55,6 +57,13 @@ struct RingBuffer {
 RingBuffer& ring_buffer() {
     static RingBuffer rb;
     return rb;
+}
+
+// Optional persistent log file. Guarded by Logger::mutex() (same lock that
+// serialises console writes and the ring buffer).
+std::ofstream& log_file() {
+    static std::ofstream f;
+    return f;
 }
 
 LoggerState& state() {
@@ -181,6 +190,34 @@ void Logger::set_min_level(LogLevel level) {
     state().min_level.store(level);
 }
 
+void Logger::set_log_file(const std::string& path, std::size_t max_bytes) {
+    std::lock_guard lock{mutex()};
+    auto& lf = log_file();
+    if (lf.is_open()) lf.close();
+    if (path.empty()) return;
+
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    const fs::path p{path};
+    if (p.has_parent_path()) fs::create_directories(p.parent_path(), ec);
+
+    // Single-generation size rotation: if the current file is already large,
+    // move it aside before reopening so the active log doesn't grow unbounded.
+    const auto sz = fs::file_size(p, ec);
+    if (!ec && sz >= max_bytes) {
+        fs::path rotated = p;
+        rotated += ".1";
+        fs::remove(rotated, ec);
+        fs::rename(p, rotated, ec);
+    }
+
+    lf.open(path, std::ios::binary | std::ios::app);
+    if (!lf) {
+        // Never throw from logging setup; console logging still works.
+        std::cerr << "[logger] failed to open log file: " << path << '\n';
+    }
+}
+
 bool Logger::color_enabled() {
     return state().color_enabled.load();
 }
@@ -201,6 +238,10 @@ void Logger::log(LogLevel level, std::string_view msg) {
 
     std::lock_guard lock{mutex()};
     ring_buffer().push(plain_line);
+    if (auto& lf = log_file(); lf.is_open()) {
+        lf << plain_line << '\n';
+        lf.flush();
+    }
     if (colored) {
         stream << style.color << ansi::dim << '[' << ts << ']' << ansi::reset << ' '
                << style.color << ansi::bold << '[' << style.tag << ']' << ansi::reset << ' '

--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -459,6 +459,34 @@ int main(int argc, char** argv) {
     install_crash_handlers((exe_dir / "crash-logs").string());
     set_crash_exe_info(exe_path_str, restart_args);
 
+    // Mirror the session to a persistent, size-rotated log file so operators
+    // have history even when stdout isn't captured (server launched by the
+    // Electron client). Best-effort; console logging is unaffected on failure.
+    Logger::set_log_file((exe_dir / "logs" / "liveplay-server.log").string());
+
+    // Crash-loop protection. Read the persisted consecutive-crash count left by
+    // any crashing predecessor; after kMaxConsecutiveCrashes back-to-back
+    // crashes the handler stops auto-restarting so a deterministic fault (e.g. a
+    // bad crash-resume project) can't relaunch forever. The count is reset once
+    // this instance has run healthily (see the heartbeat loop) or shuts cleanly.
+    constexpr int kMaxConsecutiveCrashes = 5;
+    constexpr int kCrashGuardHealthySec  = 30;
+    int prior_crash_count = 0;
+    {
+        std::ifstream cf{(exe_dir / ".crash-count").string()};
+        int v = 0;
+        if (cf && (cf >> v) && v > 0) prior_crash_count = v;
+    }
+    set_crash_restart_guard((exe_dir / ".crash-count").string(),
+                            prior_crash_count, kMaxConsecutiveCrashes);
+    if (prior_crash_count > 0) {
+        Logger::warn("Recovered from a crash ({} consecutive). Auto-restart disables after {}.",
+                     prior_crash_count, kMaxConsecutiveCrashes);
+    }
+    // Keep only the most recent crash logs in the fallback dir (project /logs/
+    // crash logs are pruned by the project itself).
+    prune_crash_logs((exe_dir / "crash-logs").string(), 20);
+
     // ------------------------------------------------------------------
     // Check for a crash-resume file left by a previous crashed instance.
     // ------------------------------------------------------------------
@@ -686,11 +714,23 @@ int main(int argc, char** argv) {
     // Heartbeat loop. Every 30 s we tick a debug line so operators can confirm
     // the process is alive over long sessions. SIGINT/SIGTERM flips g_running.
     using clock = std::chrono::steady_clock;
+    const auto program_start = clock::now();
+    bool crash_guard_reset   = false;
     auto last_heartbeat   = clock::now();
     auto last_resume_snap = clock::now();
     while (g_running.load()) {
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
         const auto now = clock::now();
+
+        // Once we've been up long enough to be considered "healthy", clear the
+        // consecutive-crash counter so isolated crashes over a long session
+        // don't accumulate toward the auto-restart give-up threshold.
+        if (!crash_guard_reset &&
+            std::chrono::duration_cast<std::chrono::seconds>(now - program_start).count()
+                >= kCrashGuardHealthySec) {
+            reset_crash_restart_guard();
+            crash_guard_reset = true;
+        }
 
         // ---- crash-resume: play item once audio has fully loaded ------------
         if (pending_resume) {
@@ -745,6 +785,9 @@ int main(int argc, char** argv) {
 
     Logger::raw("");
     Logger::info("Shutdown signal received — stopping cleanly.");
+    // A clean exit is not a crash — clear the consecutive-crash counter so the
+    // next launch starts fresh.
+    reset_crash_restart_guard();
     if (beacon) beacon->stop();
     beacon.reset();
     server->stop();

--- a/server/src/net/control_server.cpp
+++ b/server/src/net/control_server.cpp
@@ -847,6 +847,17 @@ static std::string handle_ws_message(crow::websocket::connection& conn,
                              fade ? std::to_string(*fade) + "ms" : "project default");
             state.stop_all_cues(fade);
         }
+        else if (type == "go") {
+            // Play whatever is armed as "Up Next" (override first, else the
+            // playing item's endBehavior target). Same semantics as
+            // POST /api/transport/go.
+            const auto uuid = state.go();
+            if (uuid.empty()) {
+                Logger::warn("WS go: nothing armed or derivable to play");
+                return json({{"type", "error"}, {"message", "nothing armed to GO to"}}).dump();
+            }
+            Logger::playback("GO: {}", item_playback_info(uuid, state));
+        }
         else if (type == "gain") {
             auto cue = resolve_cue(j);
             if (cue) {
@@ -1106,6 +1117,87 @@ void ControlServer::install_routes() {
             } catch (const std::exception& e) { return json_err(400, e.what()); }
         });
 
+    // ---- External-control surface (Bitfocus Companion, custom remotes) ----
+    // Compact machine-readable transport summary. Control surfaces fetch this
+    // once on connect (and after a project_changed doc_patch), then keep it
+    // fresh from the /ws push stream — no polling.
+    CROW_ROUTE(app, "/api/state/summary").methods(crow::HTTPMethod::Get)
+        ([this] {
+            try {
+                json s = state_.state_summary();
+                s["server"] = json{
+                    {"version", std::string{
+#ifdef LIVEPLAY_SERVER_VERSION
+                        LIVEPLAY_SERVER_VERSION
+#else
+                        "0.0.0"
+#endif
+                    }},
+                    {"meterBroadcastHz", cfg_.meter_broadcast_hz},
+                };
+                return json_ok(s);
+            } catch (const std::exception& e) { return json_err(500, e.what()); }
+            catch (...) { return json_err(500, "internal error"); }
+        });
+
+    // GO — play whatever is armed as "Up Next" (user override first, else the
+    // playing item's endBehavior target). GET is accepted as well as POST so
+    // the URL can be fired from a browser or a plain `curl`.
+    CROW_ROUTE(app, "/api/transport/go")
+        .methods(crow::HTTPMethod::Post, crow::HTTPMethod::Get)
+        ([this](const crow::request& req){
+            Logger::api_request("Client ({}) -> Server ({}) : {} /api/transport/go",
+                                req.remote_ip_address, impl_->server_addr,
+                                crow::method_name(req.method));
+            const std::string uuid = state_.go();
+            if (uuid.empty()) {
+                Logger::warn("GO — nothing armed or derivable to play");
+                return json_err(404, "nothing armed or playing to GO to");
+            }
+            Logger::playback("GO: {}", item_playback_info(uuid, state_));
+            return json_ok(json({{"ok", true}, {"uuid", uuid}}));
+        });
+
+    // First-class body-addressed variant of /api/project/items/by-index/…
+    // Body: { "index": [1, 11] } — an index path descending into groups.
+    CROW_ROUTE(app, "/api/transport/play_index").methods(crow::HTTPMethod::Post)
+        ([this](const crow::request& req){
+            try {
+                auto j = json::parse(req.body);
+                std::vector<int> path;
+                if (j.contains("index") && j["index"].is_array()) {
+                    for (const auto& v : j["index"]) {
+                        if (!v.is_number_integer() || v.get<int>() < 0)
+                            return json_err(400, "index must contain non-negative integers");
+                        path.push_back(v.get<int>());
+                    }
+                }
+                if (path.empty())
+                    return json_err(400, "index must be a non-empty array of child indices");
+                const std::string uuid = state_.item_uuid_by_index(path);
+                if (uuid.empty()) return json_err(404, "no item at that index");
+                Logger::playback("TRIGGER: {}", item_playback_info(uuid, state_));
+                if (!state_.trigger_item(uuid))
+                    return json_err(404, "item not loaded into engine");
+                return json_ok(json({{"ok", true}, {"uuid", uuid}, {"index", path}}));
+            } catch (const std::exception& e) { return json_err(400, e.what()); }
+        });
+
+    // Trigger the item bound to a cart slot. GET accepted for curl/browser.
+    CROW_ROUTE(app, "/api/transport/cart/<int>/play")
+        .methods(crow::HTTPMethod::Post, crow::HTTPMethod::Get)
+        ([this](const crow::request& req, int slot){
+            Logger::api_request("Client ({}) -> Server ({}) : {} /api/transport/cart/{}/play",
+                                req.remote_ip_address, impl_->server_addr,
+                                crow::method_name(req.method), slot);
+            const std::string uuid = state_.cart_slot_item_uuid(slot);
+            if (uuid.empty()) return json_err(404, "cart slot is empty");
+            Logger::playback("CART {}: {}", slot, item_playback_info(uuid, state_));
+            if (!state_.trigger_item(uuid))
+                return json_err(404, "item not loaded into engine");
+            return json_ok(json({{"ok", true}, {"slot", slot}, {"uuid", uuid}}));
+        });
+
     CROW_ROUTE(app, "/api/master/ceiling").methods(crow::HTTPMethod::Post)
         ([this](const crow::request& req){
             try {
@@ -1121,13 +1213,41 @@ void ControlServer::install_routes() {
         ([this](const crow::request& req){
             try {
                 auto j = json::parse(req.body);
-                const float db = j.value("db", 0.0f);
+                // "db" sets an absolute gain; "delta" nudges the current gain
+                // (control-surface increment/decrement without a read-modify-
+                // write race on the caller's side). "db" wins if both present.
+                float db;
+                if (!j.contains("db") && j.contains("delta") && j["delta"].is_number())
+                    db = engine_.master_gain_db() + j["delta"].get<float>();
+                else
+                    db = j.value("db", 0.0f);
                 engine_.set_master_gain_db(db);
                 broadcast_doc_patch(json{
                     {"type", "doc_patch"}, {"op", "master_gain_changed"},
                     {"db", engine_.master_gain_db()},
                 });
                 return json_ok(json({{"ok", true}, {"db", engine_.master_gain_db()}}));
+            } catch (const std::exception& e) { return json_err(400, e.what()); }
+        });
+
+    // Master brickwall limiter enable/bypass. POST body { "enabled": bool };
+    // omitting "enabled" toggles the current state (single-button surfaces).
+    CROW_ROUTE(app, "/api/master/limiter").methods(crow::HTTPMethod::Get)
+        ([this]{ return json_ok(json({{"enabled", engine_.limiter_enabled()}})); });
+    CROW_ROUTE(app, "/api/master/limiter").methods(crow::HTTPMethod::Post)
+        ([this](const crow::request& req){
+            try {
+                auto j = json::parse(req.body.empty() ? std::string{"{}"} : req.body);
+                const bool enabled =
+                    (j.contains("enabled") && j["enabled"].is_boolean())
+                        ? j["enabled"].get<bool>()
+                        : !engine_.limiter_enabled();
+                engine_.set_limiter_enabled(enabled);
+                broadcast_doc_patch(json{
+                    {"type", "doc_patch"}, {"op", "limiter_changed"},
+                    {"enabled", enabled},
+                });
+                return json_ok(json({{"ok", true}, {"enabled", enabled}}));
             } catch (const std::exception& e) { return json_err(400, e.what()); }
         });
 
@@ -2327,6 +2447,34 @@ void ControlServer::install_routes() {
             Logger::api_response("Client ({}) <- Server ({}) : POST /api/project/items/{}/stop OK",
                                  req.remote_ip_address, impl_->server_addr, uuid);
             return json_ok(json({{"ok", true}}));
+        });
+    // Pause / resume hold the playhead without unloading. REST mirror of the
+    // WS "pause"/"resume" messages so stateless control surfaces can use them.
+    CROW_ROUTE(app, "/api/project/items/<string>/pause").methods(crow::HTTPMethod::Post)
+        ([this](const crow::request& req, std::string uuid){
+            Logger::api_request("Client ({}) -> Server ({}) : POST /api/project/items/{}/pause",
+                                req.remote_ip_address, impl_->server_addr, uuid);
+            const auto cue = state_.item_to_cue_id(uuid);
+            if (!cue) return json_err(404, "item not loaded into engine");
+            if (auto* pi = engine_.find_cue(*cue)) {
+                Logger::playback("PAUSE: {}", item_playback_info(uuid, state_));
+                pi->pause();
+                return json_ok(json({{"ok", true}}));
+            }
+            return json_err(404, "item not loaded into engine");
+        });
+    CROW_ROUTE(app, "/api/project/items/<string>/resume").methods(crow::HTTPMethod::Post)
+        ([this](const crow::request& req, std::string uuid){
+            Logger::api_request("Client ({}) -> Server ({}) : POST /api/project/items/{}/resume",
+                                req.remote_ip_address, impl_->server_addr, uuid);
+            const auto cue = state_.item_to_cue_id(uuid);
+            if (!cue) return json_err(404, "item not loaded into engine");
+            if (auto* pi = engine_.find_cue(*cue)) {
+                Logger::playback("RESUME: {}", item_playback_info(uuid, state_));
+                pi->resume();
+                return json_ok(json({{"ok", true}}));
+            }
+            return json_err(404, "item not loaded into engine");
         });
     CROW_ROUTE(app, "/api/project/items/<string>/seek").methods(crow::HTTPMethod::Post)
         ([this](const crow::request& req, std::string uuid){

--- a/server/src/net/control_server.cpp
+++ b/server/src/net/control_server.cpp
@@ -416,6 +416,11 @@ void ControlServer::broadcast_loop() {
     auto next_tick = clock::now() + period;
 
     while (running_.load(std::memory_order_acquire)) {
+        // Guard the entire tick: an exception escaping this thread would call
+        // std::terminate() and take the whole audio process down mid-show.
+        // Log-and-continue instead so a transient fault (e.g. a flaky media
+        // share throwing out of a filesystem call) just drops one meter frame.
+        try {
 
         // Build the meters payload.
         json payload;
@@ -572,6 +577,16 @@ void ControlServer::broadcast_loop() {
         std::this_thread::sleep_until(next_tick);
         next_tick += period;
         if (next_tick < clock::now()) next_tick = clock::now() + period;
+
+        } catch (const std::exception& e) {
+            Logger::error("broadcast_loop: unhandled exception (continuing): {}", e.what());
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+            next_tick = clock::now() + period;
+        } catch (...) {
+            Logger::error("broadcast_loop: unknown exception (continuing).");
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+            next_tick = clock::now() + period;
+        }
     }
 }
 
@@ -611,18 +626,23 @@ void ControlServer::waveform_worker() {
             impl_->waveform_q.pop_front();
         }
 
+        // Guard the whole task: an exception here (e.g. the throwing fs::exists
+        // overload faulting on a disconnected network share, or compute_waveform
+        // throwing) would escape this thread and std::terminate() the process.
+        try {
+
+        std::error_code fs_ec;
         const fs::path json_file = task.waveforms_dir.empty()
             ? fs::path{}
             : task.waveforms_dir / (task.item_uuid + ".json");
 
         // Remove stale cache entry when a forced regeneration is requested.
-        if (task.force && !json_file.empty() && fs::exists(json_file)) {
-            std::error_code ec;
-            fs::remove(json_file, ec);
+        if (task.force && !json_file.empty() && fs::exists(json_file, fs_ec)) {
+            fs::remove(json_file, fs_ec);
         }
 
         // Serve from disk cache when available (skips full audio decode).
-        if (!json_file.empty() && fs::exists(json_file)) {
+        if (!json_file.empty() && fs::exists(json_file, fs_ec)) {
             try {
                 std::ifstream cache_f(json_file);
                 const auto cached = json::parse(cache_f);
@@ -692,6 +712,12 @@ void ControlServer::waveform_worker() {
 
         broadcast_doc_patch(std::move(patch));
         Logger::info("waveform_worker: done for item_uuid '{}'", task.item_uuid);
+
+        } catch (const std::exception& e) {
+            Logger::error("waveform_worker: unhandled exception (skipping task): {}", e.what());
+        } catch (...) {
+            Logger::error("waveform_worker: unknown exception (skipping task).");
+        }
     }
 }
 


### PR DESCRIPTION
LTC generator was calling configure() (→ reset()) every render block, forcing biphase-mark polarity to +1, corrupting the timecode signal. 
Add LTCGenerator::set_offset() and use it on the hot path; configure() now only runs on sample/frame-rate/enable changes.

Increase Server Reliability:
- Guard broadcast_loop() and waveform_worker() with try/catch so an escaping exception can no longer std::terminate() the audio process.
- Rewrite the POSIX fatal-signal path to be async-signal-safe.
- Add crash-loop protection: a persisted consecutive-crash counter that stops auto-restart after N (default 5) back-to-back crashes; reset on healthy uptime and clean shutdown.
- Make crash-resume state a lock-free double buffer so a torn read can no longer persist a garbled project path/uuid.
- Crash-log filenames now include seconds + PID.
- Add an always-on, size-rotated rolling server log file so history survives when stdout isn't captured.