### PR TITLE
fix/server hardening, playback fixes, dsp robustness, api error handling improvements

### DIFF
--- a/server/include/liveplay/audio/ltc_generator.hpp
+++ b/server/include/liveplay/audio/ltc_generator.hpp
@@ -76,6 +76,15 @@ public:
                    std::chrono::nanoseconds offset = std::chrono::nanoseconds{0},
                    float amplitude_lin = 0.5f);
 
+    // Update ONLY the timecode offset without disturbing the running encoder
+    // state. This is the per-block hot path: unlike configure()/reset() it does
+    // not rewind current_frame_number_ or force polarity_, so biphase-mark
+    // continuity across block boundaries is preserved. render_block() will still
+    // resync naturally on the block where the resulting frame number changes.
+    void set_offset(std::chrono::nanoseconds offset) noexcept {
+        offset_ns_ = offset.count();
+    }
+
     // Reset the encoder to the beginning of the cue (playhead == 0).
     void reset(std::chrono::nanoseconds offset = std::chrono::nanoseconds{0}) noexcept;
 

--- a/server/include/liveplay/audio/playback_item.hpp
+++ b/server/include/liveplay/audio/playback_item.hpp
@@ -109,8 +109,17 @@ public:
 
     // ---- Mutators --------------------------------------------------------
     void set_gain_db(float db) noexcept;
-    void set_fade_in (std::chrono::milliseconds d) noexcept { desc_.fade_in_duration  = d; }
-    void set_fade_out(std::chrono::milliseconds d) noexcept { desc_.fade_out_duration = d; }
+    // Fade durations are mirrored into atomics so the audio thread can read the
+    // fade-out length without racing these control-thread writes (desc_ keeps a
+    // copy for serialization and control-thread reads).
+    void set_fade_in (std::chrono::milliseconds d) noexcept {
+        desc_.fade_in_duration  = d;
+        fade_in_ms_.store(d.count(), std::memory_order_release);
+    }
+    void set_fade_out(std::chrono::milliseconds d) noexcept {
+        desc_.fade_out_duration = d;
+        fade_out_ms_.store(d.count(), std::memory_order_release);
+    }
     void set_ltc_enabled(bool enabled);
     void set_ltc_frame_rate(LTCFrameRate fr);
     void set_ltc_offset(std::chrono::nanoseconds offset) noexcept;
@@ -172,6 +181,17 @@ public:
     ChannelCount     source_channel_count() const noexcept;  // includes LTC if enabled
     PlaybackItemStats stats() const noexcept;
 
+    // True if the decoder returned an unexpected error mid-playback (i.e. not a
+    // clean end-of-file) since the flag was last cleared — e.g. a file dropping
+    // off a flaky network/USB drive. Lets the control thread surface a warning
+    // without any logging on the audio path. clear_decode_error() resets it.
+    bool had_decode_error() const noexcept {
+        return decode_error_.load(std::memory_order_relaxed);
+    }
+    void clear_decode_error() noexcept {
+        decode_error_.store(false, std::memory_order_relaxed);
+    }
+
     MeterSnapshot source_meter(ChannelIndex ch) const noexcept;
     // Consuming read (resets the channel's max-since-read). Broadcaster only.
     MeterSnapshot source_meter_consume(ChannelIndex ch) noexcept;
@@ -197,8 +217,14 @@ private:
     // grabs a try_lock and falls back to silence on contention (rare).
     std::unique_ptr<ma_decoder> decoder_;
     std::mutex                  decoder_mutex_;
-    bool                        decoder_ready_ = false;
+    std::atomic<bool>           decoder_ready_{false};
     ChannelCount                file_channels_ = 0;
+
+    // Interleaved decode staging buffer. Sized in load(); only touched inside
+    // the decoder_mutex_-guarded region of render_block(), so keeping it as a
+    // member (rather than a thread_local that reallocates on the audio thread's
+    // first block) moves the allocation to load() on the control thread.
+    std::vector<Sample>         interleave_buf_;
 
     // Transport + gain state (hot atomics).
     std::atomic<TransportState> transport_{TransportState::Stopped};
@@ -210,6 +236,14 @@ private:
     std::atomic<float>          fade_end_linear_{1.0f};
     std::atomic<long long>      fade_duration_samples_{0};
     std::atomic<long long>      fade_elapsed_samples_{0};
+
+    // Atomic mirrors of desc_.fade_in/out_duration (in ms) for lock-free reads
+    // from the audio thread. Written by set_fade_in()/set_fade_out().
+    std::atomic<long long>      fade_in_ms_{0};
+    std::atomic<long long>      fade_out_ms_{0};
+
+    // Set by render_block() on an unexpected decoder error (see had_decode_error).
+    std::atomic<bool>           decode_error_{false};
 
     // Playhead in mix-rate frames. Audio thread is the only writer.
     std::atomic<std::uint64_t>  playhead_frames_{0};

--- a/server/include/liveplay/core/project_state.hpp
+++ b/server/include/liveplay/core/project_state.hpp
@@ -244,6 +244,24 @@ public:
     // server to seed newly-connected clients with the live override state.
     std::string next_item_override() const;
 
+    // ---- External-control surface (Bitfocus Companion, custom remotes) ----
+    // Compact machine-readable transport summary: project header facts, every
+    // on-air item (name, index path, elapsed/remaining), the effective "Up
+    // Next" target, master gain/limiter state and cart-slot bindings. Built
+    // for polling-free control surfaces — fetch once on connect, then keep it
+    // fresh from the /ws push messages (cue_state, meters, doc_patch).
+    json state_summary() const;
+
+    // GO: trigger whatever is armed as "Up Next". Uses the user-set override
+    // when present (consumed on success), otherwise derives the target from
+    // the currently-playing item's endBehavior — mirroring the client's GO
+    // button. Returns the uuid triggered, or empty if nothing was armed /
+    // derivable / loaded.
+    std::string go();
+
+    // Item uuid bound to a cart slot, or empty if the slot is unbound.
+    std::string cart_slot_item_uuid(int slot) const;
+
     // ---- Per-device routing ---------------------------------------------
     // Ensure a "device mixer" exists for `device_name` (the user-visible
     // name from /api/devices). Opens the audio device if needed, creates a

--- a/server/include/liveplay/crash_handler.hpp
+++ b/server/include/liveplay/crash_handler.hpp
@@ -8,6 +8,7 @@
 // ============================================================================
 #pragma once
 
+#include <cstddef>
 #include <string>
 
 namespace liveplay {
@@ -15,6 +16,26 @@ namespace liveplay {
 // Call once early in main(). Idempotent. `log_dir` is the fallback directory
 // for crash logs when no project dir is known; if empty, cwd is used.
 void install_crash_handlers(const std::string& log_dir = "");
+
+// Configure crash-loop protection. `counter_file` is a path where the
+// consecutive-crash count is persisted across restarts; `consecutive_so_far`
+// is the count read from that file at startup; `max_consecutive` is the number
+// of back-to-back crashes after which the handler stops auto-restarting (so a
+// deterministic crash can't relaunch forever). Call once at startup, after
+// set_crash_exe_info().
+void set_crash_restart_guard(const std::string& counter_file,
+                             int consecutive_so_far,
+                             int max_consecutive);
+
+// Reset the consecutive-crash count to zero (in memory and on disk). Call once
+// the process has been running healthily for a while, and on clean shutdown, so
+// isolated crashes over a long session don't accumulate toward the give-up
+// threshold.
+void reset_crash_restart_guard();
+
+// Delete all but the newest `keep` crash-log files in `dir`. Best-effort;
+// safe to call at startup (never from a signal handler).
+void prune_crash_logs(const std::string& dir, std::size_t keep);
 
 // Tell the crash handler where the server executable lives and what arguments
 // it was started with (so it can relaunch after a crash). Call once after

--- a/server/include/liveplay/logger.hpp
+++ b/server/include/liveplay/logger.hpp
@@ -49,6 +49,15 @@ public:
     // Set the minimum level that will be emitted (default: Info; Debug below).
     static void set_min_level(LogLevel level);
 
+    // Mirror every log line (plain text, ANSI-stripped) to a persistent file so
+    // operators have session history even when stdout isn't captured (e.g. the
+    // server launched by the Electron client). If the file already exceeds
+    // `max_bytes`, it is rotated to "<path>.1" first (single generation). Pass
+    // an empty path to disable file logging. Best-effort: a file-open failure is
+    // logged once and never blocks console logging.
+    static void set_log_file(const std::string& path,
+                             std::size_t max_bytes = 10u * 1024 * 1024);
+
     // -------------------- primary API ---------------------------------------
     template <typename... Args>
     static void debug(std::format_string<Args...> fmt, Args&&... args) {

--- a/server/include/liveplay/net/control_server.hpp
+++ b/server/include/liveplay/net/control_server.hpp
@@ -20,6 +20,12 @@
 //   POST   /api/cues/{id}/fade               — { "in_ms": N, "out_ms": M }
 //   POST   /api/cues/{id}/ltc                — { "enabled":..., "fps":..., "offset_ns":... }
 //   POST   /api/transport/stop_all           — { "fade_ms": 250 }
+//   GET    /api/state/summary                — compact transport state (external control)
+//   POST   /api/transport/go                 — play the armed "Up Next" item
+//   POST   /api/transport/play_index         — { "index": [1, 11] } trigger by index path
+//   POST   /api/transport/cart/{slot}/play   — trigger a cart slot's bound item
+//   GET    /api/master/limiter               — { "enabled": bool }
+//   POST   /api/master/limiter               — { "enabled": bool } (omit = toggle)
 //   POST   /api/routing/item_to_mixer        — { cue, source_channel, mixer, gain_db }
 //   POST   /api/routing/mixer_to_master      — { mixer, master_channel, gain_db }
 //   POST   /api/routing/master_to_device     — { master_channel, device, hw_channel }

--- a/server/src/audio/engine.cpp
+++ b/server/src/audio/engine.cpp
@@ -18,6 +18,12 @@
 #  include <windows.h>   // SetThreadPriority
 #endif
 
+#if defined(_M_X64) || defined(_M_IX86) || defined(__x86_64__) || defined(__i386__)
+#  include <xmmintrin.h>   // _MM_SET_FLUSH_ZERO_MODE
+#  include <pmmintrin.h>   // _MM_SET_DENORMALS_ZERO_MODE
+#  define LIVEPLAY_HAVE_SSE_DENORMAL 1
+#endif
+
 namespace liveplay::audio {
 
 namespace {
@@ -886,6 +892,14 @@ float AudioEngine::read_master_gain_reduction_db(MasterChannelIndex master) cons
 //     "preview without an output device assigned" case).
 void AudioEngine::render_loop() {
     Logger::debug("Render thread started.");
+#if defined(LIVEPLAY_HAVE_SSE_DENORMAL)
+    // Flush-to-zero + denormals-are-zero for this thread. The limiter and meter
+    // states decay exponentially toward zero during silence and can enter
+    // denormal range, which incurs large per-sample CPU penalties on x86;
+    // FTZ/DAZ makes those flush to zero with no audible consequence.
+    _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
+    _MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_ON);
+#endif
     const auto block_duration =
         std::chrono::nanoseconds{static_cast<long long>(cfg_.render_block) * 1'000'000'000LL /
                                  static_cast<long long>(cfg_.mix_sample_rate)};

--- a/server/src/audio/limiter.cpp
+++ b/server/src/audio/limiter.cpp
@@ -80,7 +80,19 @@ void Limiter::recompute_window_max() noexcept {
 
 void Limiter::process(Sample* samples, std::size_t frame_count) noexcept {
     if (!samples || frame_count == 0) return;
-    if (peak_window_.empty() || delay_.empty()) return;   // not configured
+    if (peak_window_.empty() || delay_.empty()) {
+        // Not configured — still provide a safety backstop rather than passing
+        // audio through untouched: sanitise non-finite samples and hard-clip to
+        // 0 dBFS so an unconfigured limiter can never leak overs to the hardware.
+        for (std::size_t i = 0; i < frame_count; ++i) {
+            float x = samples[i];
+            if (!finite_and_finite_enough(x)) x = 0.0f;
+            if (x >  1.0f) x =  1.0f;
+            if (x < -1.0f) x = -1.0f;
+            samples[i] = x;
+        }
+        return;
+    }
 
     const std::size_t window_size = peak_window_.size();
     const float       ceiling     = ceiling_lin_;

--- a/server/src/audio/playback_item.cpp
+++ b/server/src/audio/playback_item.cpp
@@ -50,6 +50,8 @@ PlaybackItem::PlaybackItem(PlaybackItemDesc desc)
     : desc_(std::move(desc)) {
     gain_target_linear_.store(1.0f);
     gain_current_linear_.store(1.0f);
+    fade_in_ms_.store(desc_.fade_in_duration.count());
+    fade_out_ms_.store(desc_.fade_out_duration.count());
     ltc_enabled_atomic_.store(desc_.ltc_enabled);
     ltc_offset_ns_.store(desc_.ltc_offset.count());
     if (desc_.ltc_enabled) {
@@ -63,9 +65,13 @@ PlaybackItem::~PlaybackItem() {
 }
 
 bool PlaybackItem::load() {
+    // Never swap the decoder out from under active playback — reset transport,
+    // playhead and fade state first (mirrors unload()'s stop_now()).
+    stop_now();
     std::lock_guard lock{decoder_mutex_};
 
     decoder_ready_ = false;
+    decode_error_.store(false, std::memory_order_relaxed);
     if (decoder_) {
         ma_decoder_uninit(decoder_.get());
         decoder_.reset();
@@ -114,6 +120,12 @@ bool PlaybackItem::load() {
 
     const ChannelCount total = file_channels_ + (desc_.ltc_enabled ? 1u : 0u);
     resize_meters(total);
+
+    // Pre-size the interleaved decode staging buffer so render_block() doesn't
+    // allocate on the audio thread for the common fixed-block-size case.
+    interleave_buf_.assign(
+        static_cast<std::size_t>(desc_.render_block) *
+            std::max<ChannelCount>(1u, file_channels_), 0.0f);
 
     decoder_ready_ = true;
     Logger::info("PlaybackItem[{}] loaded '{}' ({} ch, {} Hz mix-rate, LTC={})",
@@ -164,16 +176,27 @@ void PlaybackItem::play() {
     }
     const TransportState st = transport_.load(std::memory_order_acquire);
     if (st == TransportState::Playing || st == TransportState::FadingIn) return;
+    // A paused cue resumes in place — don't restart the fade envelope (which
+    // would snap the gain and re-run the fade-in).
+    if (st == TransportState::Paused) { resume(); return; }
 
     // Reset natural-end flags so take_natural_end() doesn't fire for a
     // stale previous play on this same item.
     stopped_naturally_.store(false, std::memory_order_release);
     fading_out_naturally_.store(false, std::memory_order_release);
 
+    // Fade in from the CURRENT gain, not a hardcoded 0. Re-triggering a cue that
+    // is mid stop-fade (FadingOut) would otherwise dip to silence before fading
+    // back up — an audible click/dip. From Stopped the current gain is whatever
+    // stop_now() left (the target), so start from 0 to actually fade in.
+    const float from = (st == TransportState::FadingOut)
+                           ? gain_current_linear_.load(std::memory_order_acquire)
+                           : 0.0f;
+
     // Begin a fade-in if configured; otherwise jump straight to full gain.
     const auto fade = desc_.fade_in_duration;
     if (fade.count() > 0) {
-        start_fade(/*from*/ 0.0f,
+        start_fade(/*from*/ from,
                    /*to*/   gain_target_linear_.load(),
                    fade,
                    TransportState::FadingIn,
@@ -240,12 +263,25 @@ void PlaybackItem::resume() {
 
 void PlaybackItem::seek_seconds(double seconds) {
     if (seconds < 0) seconds = 0;
-    const auto frame = static_cast<ma_uint64>(seconds * desc_.mix_sample_rate);
+    ma_uint64 frame = static_cast<ma_uint64>(seconds * desc_.mix_sample_rate);
     {
         std::lock_guard lock{decoder_mutex_};
-        if (decoder_) ma_decoder_seek_to_pcm_frame(decoder_.get(), frame);
+        if (decoder_) {
+            const ma_result r = ma_decoder_seek_to_pcm_frame(decoder_.get(), frame);
+            if (r != MA_SUCCESS) {
+                // Seek failed (e.g. seeking past the true end of a VBR file whose
+                // reported duration overshoots the decodable length). Resync the
+                // playhead to the decoder's actual cursor so out-point / loop
+                // checks and UI reporting don't drift for the rest of the cue.
+                ma_uint64 cursor = 0;
+                if (ma_decoder_get_cursor_in_pcm_frames(decoder_.get(), &cursor) == MA_SUCCESS)
+                    frame = cursor;
+            }
+        }
+        // Store inside the lock so the audio thread can't decode from the new
+        // decoder position while still reading the pre-seek playhead value.
+        playhead_frames_.store(frame, std::memory_order_release);
     }
-    playhead_frames_.store(frame, std::memory_order_release);
     if (ltc_) {
         // LTC resyncs lazily inside render_block(), but a hint here keeps the
         // generator's internal frame counter from doing a full rebuild on the
@@ -309,9 +345,14 @@ void PlaybackItem::set_out_point_seconds(double seconds) noexcept {
 
 void PlaybackItem::set_loop(bool enabled, double in_seconds) noexcept {
     const auto rate = static_cast<double>(desc_.mix_sample_rate);
-    const auto in_frames = (in_seconds <= 0.0)
+    auto in_frames = (in_seconds <= 0.0)
         ? std::uint64_t{0}
         : static_cast<std::uint64_t>(in_seconds * rate);
+    // A loop-in point at or past the out-point would make render_block() re-hit
+    // the out-point on every block — a rapid Stopped/loop retrigger with silence
+    // and high seek churn. Fall back to looping from the start in that case.
+    const auto out_pt = out_point_frames_.load(std::memory_order_acquire);
+    if (out_pt > 0 && in_frames >= out_pt) in_frames = 0;
     loop_in_frames_.store(in_frames, std::memory_order_release);
     loop_enabled_.store(enabled, std::memory_order_release);
 }
@@ -388,10 +429,10 @@ void PlaybackItem::start_fade(float from_lin, float to_lin,
     gain_current_linear_.store(from_lin, std::memory_order_release);
     transport_.store(during, std::memory_order_release);
 
-    // We pre-store `after_complete` into a static-ish slot by encoding it in
-    // a sign convention: positive duration + transport==FadingIn → Playing
-    // afterwards; FadingOut → Stopped afterwards. Render block reads transport_
-    // to decide. So we don't need to store after_complete separately.
+    // `after_complete` is intentionally not stored: render_block() derives the
+    // post-fade transport purely from `during` (FadingIn → Playing, FadingOut →
+    // Stopped). The parameter is kept for call-site readability only. All
+    // current callers pass the matching pair, so the two never disagree.
     (void)after_complete;
 }
 
@@ -405,7 +446,12 @@ void PlaybackItem::resize_meters(ChannelCount n) {
     }
 }
 
+// The three meter setters below iterate source_meters_, which resize_meters()
+// (called from load()/set_ltc_enabled() under decoder_mutex_) can reallocate.
+// Take the same lock so a concurrent reload/LTC-toggle can't invalidate the
+// vector mid-iteration.
 void PlaybackItem::set_meter_ballistics(const MeterBallistics& b) noexcept {
+    std::lock_guard lock{decoder_mutex_};
     meter_ballistics_ = b;
     for (auto& m : source_meters_) {
         if (m) m->configure(desc_.mix_sample_rate, b);
@@ -413,6 +459,7 @@ void PlaybackItem::set_meter_ballistics(const MeterBallistics& b) noexcept {
 }
 
 void PlaybackItem::set_true_peak_metering(bool enabled) noexcept {
+    std::lock_guard lock{decoder_mutex_};
     meter_true_peak_ = enabled;
     for (auto& m : source_meters_) {
         if (m) m->set_true_peak_enabled(enabled);
@@ -420,6 +467,7 @@ void PlaybackItem::set_true_peak_metering(bool enabled) noexcept {
 }
 
 void PlaybackItem::set_loudness_metering(bool enabled) noexcept {
+    std::lock_guard lock{decoder_mutex_};
     meter_loudness_ = enabled;
     for (auto& m : source_meters_) {
         if (m) m->set_loudness_enabled(enabled);
@@ -447,19 +495,27 @@ std::size_t PlaybackItem::render_block(Sample* const* out_channel_buffers,
     if (!lock.owns_lock() || !decoder_) return 0;
 
     // ---- Decode interleaved file audio ----
-    static thread_local std::vector<Sample> interleaved;
+    // interleave_buf_ is pre-sized in load(); the resize here is only a fallback
+    // for a larger-than-configured block. We hold decoder_mutex_, so this can't
+    // race load()/resize_meters().
     const std::size_t needed = frame_count * static_cast<std::size_t>(file_channels_);
-    if (interleaved.size() < needed) interleaved.resize(needed);
+    if (interleave_buf_.size() < needed) interleave_buf_.resize(needed);
 
     ma_uint64 frames_read = 0;
     const ma_result rv = ma_decoder_read_pcm_frames(
         decoder_.get(),
-        interleaved.data(),
+        interleave_buf_.data(),
         static_cast<ma_uint64>(frame_count),
         &frames_read);
-    if (rv != MA_SUCCESS && rv != MA_AT_END) frames_read = 0;
+    if (rv != MA_SUCCESS && rv != MA_AT_END) {
+        // Unexpected decoder error mid-playback (distinct from clean EOF, which
+        // is MA_AT_END). Flag it so the control thread can surface a "file
+        // dropped out" warning; no logging on the audio path.
+        frames_read = 0;
+        decode_error_.store(true, std::memory_order_relaxed);
+    }
 
-    deinterleave_to(interleaved.data(),
+    deinterleave_to(interleave_buf_.data(),
                     static_cast<std::size_t>(frames_read),
                     file_channels_,
                     out_channel_buffers,
@@ -614,7 +670,8 @@ std::size_t PlaybackItem::render_block(Sample* const* out_channel_buffers,
             const auto cur = transport_.load(std::memory_order_acquire);
             if (cur == TransportState::Playing || cur == TransportState::FadingIn) {
                 fading_out_naturally_.store(true, std::memory_order_release);
-                const auto fade = desc_.fade_out_duration;
+                const auto fade = std::chrono::milliseconds{
+                    fade_out_ms_.load(std::memory_order_acquire)};
                 if (fade.count() > 0) {
                     start_fade(gain_current_linear_.load(), 0.0f, fade,
                                TransportState::FadingOut, TransportState::Stopped);

--- a/server/src/audio/playback_item.cpp
+++ b/server/src/audio/playback_item.cpp
@@ -472,10 +472,13 @@ std::size_t PlaybackItem::render_block(Sample* const* out_channel_buffers,
             static_cast<long long>(playhead_frames_.load(std::memory_order_relaxed));
         const auto playhead_ns = std::chrono::nanoseconds{
             playhead_frames * 1'000'000'000LL / static_cast<long long>(desc_.mix_sample_rate)};
-        // Refresh offset in case the control thread changed it.
-        ltc_->configure(desc_.mix_sample_rate, desc_.ltc_frame_rate,
-                        std::chrono::nanoseconds{ltc_offset_ns_.load(std::memory_order_acquire)},
-                        /*amplitude*/ 0.5f);
+        // Refresh offset in case the control thread changed it. Use set_offset()
+        // — NOT configure() — so we don't reset the encoder state every block
+        // (that would force polarity back to +1 each block and corrupt the
+        // biphase-mark signal). Sample-rate / frame-rate / enable changes go
+        // through configure() from their dedicated setters instead.
+        ltc_->set_offset(
+            std::chrono::nanoseconds{ltc_offset_ns_.load(std::memory_order_acquire)});
         ltc_->render_block(out_channel_buffers[file_channels_], frame_count, playhead_ns);
     }
 

--- a/server/src/core/project_state.cpp
+++ b/server/src/core/project_state.cpp
@@ -2429,6 +2429,263 @@ std::string ProjectState::next_item_override() const {
     return next_item_override_;
 }
 
+// ---------------------------------------------------------------------------
+// External-control surface (Bitfocus Companion, custom remotes).
+// ---------------------------------------------------------------------------
+static const char* transport_state_name(audio::TransportState t) {
+    switch (t) {
+        case audio::TransportState::Playing:   return "playing";
+        case audio::TransportState::FadingIn:  return "fading_in";
+        case audio::TransportState::FadingOut: return "fading_out";
+        case audio::TransportState::Paused:    return "paused";
+        default:                               return "stopped";
+    }
+}
+
+json ProjectState::state_summary() const {
+    // Doc-derived facts are snapshotted under mutex_ first; engine transport
+    // is read afterwards (engine calls take their own locks) and the auto
+    // "Up Next" derivation re-acquires mutex_ at the end. Never call into the
+    // engine while holding mutex_ from here — play_item does the same dance.
+    struct ItemFacts {
+        std::string      name;
+        double           duration  = 0.0;  // full-file seconds (0 = unknown)
+        double           in_point  = 0.0;
+        double           out_point = 0.0;  // 0 = play to end
+        std::vector<int> index;            // playlist index path; empty for cart-only items
+    };
+    std::unordered_map<std::string, ItemFacts> facts;
+    // uuid → (cue, duration from decode metadata)
+    std::vector<std::tuple<std::string, audio::CueId, double>> cue_pairs;
+    std::string override_uuid;
+    json project_block;
+    json cart_bindings = json::array();
+
+    {
+        std::lock_guard lock{mutex_};
+
+        const std::size_t item_count =
+            (document_.contains("items") && document_["items"].is_array())
+                ? document_["items"].size() : 0;
+        project_block = json{
+            {"name",           document_.value("name", "")},
+            {"itemCount",      item_count},
+            {"hasOpenProject", item_count > 0 || !project_file_path_.empty()},
+            {"audioLoading",   loading_audio_.load(std::memory_order_acquire)},
+        };
+
+        // Walk the playlist tree recording every item's display facts and its
+        // index path — the same path /api/transport/play_index accepts.
+        std::function<void(const json&, std::vector<int>&)> walk;
+        walk = [&](const json& arr, std::vector<int>& path) {
+            if (!arr.is_array()) return;
+            for (int i = 0; i < static_cast<int>(arr.size()); ++i) {
+                const auto& it = arr[i];
+                if (!it.is_object()) continue;
+                path.push_back(i);
+                const std::string uuid = it.value("uuid", std::string{});
+                if (!uuid.empty()) {
+                    ItemFacts f;
+                    f.name      = it.value("displayName", std::string{});
+                    f.duration  = it.value("duration", 0.0);
+                    f.in_point  = it.value("inPoint",  0.0);
+                    f.out_point = it.value("outPoint", 0.0);
+                    f.index     = path;
+                    facts.emplace(uuid, std::move(f));
+                }
+                if (it.value("type", std::string{}) == "group" &&
+                    it.contains("children")) {
+                    walk(it["children"], path);
+                }
+                path.pop_back();
+            }
+        };
+        std::vector<int> path;
+        if (document_.contains("items")) walk(document_["items"], path);
+
+        // Cart-only items live outside the playlist tree — record their names
+        // so cart bindings resolve, but with no index path.
+        if (document_.contains("cartOnlyItems") && document_["cartOnlyItems"].is_array()) {
+            for (const auto& it : document_["cartOnlyItems"]) {
+                if (!it.is_object()) continue;
+                const std::string uuid = it.value("uuid", std::string{});
+                if (uuid.empty() || facts.count(uuid)) continue;
+                ItemFacts f;
+                f.name      = it.value("displayName", std::string{});
+                f.duration  = it.value("duration", 0.0);
+                f.in_point  = it.value("inPoint",  0.0);
+                f.out_point = it.value("outPoint", 0.0);
+                facts.emplace(uuid, std::move(f));
+            }
+        }
+
+        cue_pairs.reserve(item_uuid_to_cue_.size());
+        for (const auto& [uuid, cue] : item_uuid_to_cue_) {
+            double duration = 0.0;
+            if (auto it = cues_.find(cue.value); it != cues_.end())
+                duration = it->second.duration_seconds;
+            cue_pairs.emplace_back(uuid, cue, duration);
+        }
+
+        override_uuid = next_item_override_;
+
+        if (document_.contains("cartItems") && document_["cartItems"].is_array()) {
+            for (const auto& c : document_["cartItems"]) {
+                if (c.is_object()) cart_bindings.push_back(c);
+            }
+        }
+    }
+
+    // Engine pass: which cues are on air, and where are their playheads.
+    struct OnAir {
+        std::string           uuid;
+        std::string           cue_id;
+        audio::TransportState transport;
+        double                playhead = 0.0;
+        double                duration = 0.0;
+    };
+    std::vector<OnAir> on_air;
+    for (const auto& [uuid, cue, duration] : cue_pairs) {
+        auto* pi = engine_.find_cue(cue);
+        if (!pi) continue;
+        const auto s = pi->stats();
+        if (s.transport == audio::TransportState::Stopped) continue;
+        on_air.push_back(OnAir{uuid, cue.value, s.transport, s.playhead_seconds, duration});
+    }
+    // Document order (index path, lexicographic); cart-only items last.
+    std::sort(on_air.begin(), on_air.end(), [&](const OnAir& a, const OnAir& b) {
+        const auto& ia = facts[a.uuid].index;
+        const auto& ib = facts[b.uuid].index;
+        if (ia.empty() != ib.empty()) return ib.empty();
+        return ia < ib;
+    });
+
+    json playing = json::array();
+    for (const auto& e : on_air) {
+        const auto& f = facts[e.uuid];
+        // Effective bounds honour inPoint / outPoint trims the same way the
+        // client's transport display does.
+        const double duration  = (f.duration > 0.0) ? f.duration : e.duration;
+        const double end       = (f.out_point > f.in_point) ? f.out_point
+                                : (duration > 0.0 ? duration : e.playhead);
+        const double elapsed   = std::max(0.0, e.playhead - f.in_point);
+        const double eff_dur   = std::max(0.0, end - f.in_point);
+        json entry{
+            {"itemUuid",     e.uuid},
+            {"cueId",        e.cue_id},
+            {"name",         f.name},
+            {"transport",    transport_state_name(e.transport)},
+            {"paused",       e.transport == audio::TransportState::Paused},
+            {"playheadSec",  e.playhead},
+            {"elapsedSec",   elapsed},
+            {"durationSec",  eff_dur},
+            {"remainingSec", std::max(0.0, eff_dur - elapsed)},
+        };
+        if (!f.index.empty()) entry["index"] = f.index;
+        playing.push_back(std::move(entry));
+    }
+
+    // Effective "Up Next": user override first, else derived from the
+    // currently-playing item's endBehavior (client GO-button parity).
+    std::string next_uuid   = override_uuid;
+    std::string next_source = next_uuid.empty() ? "" : "override";
+    if (next_uuid.empty() && !on_air.empty()) {
+        std::lock_guard lock{mutex_};
+        for (const auto& e : on_air) {
+            const auto n = resolve_next_item_locked(e.uuid);
+            if (!n.empty()) { next_uuid = n; next_source = "auto"; break; }
+        }
+    }
+    json next = nullptr;
+    if (!next_uuid.empty()) {
+        next = json{{"itemUuid", next_uuid}, {"source", next_source}};
+        if (auto it = facts.find(next_uuid); it != facts.end()) {
+            next["name"] = it->second.name;
+            if (!it->second.index.empty()) next["index"] = it->second.index;
+        }
+    }
+
+    // Cart bindings, decorated with the bound item's name + live state.
+    json cart = json::array();
+    for (const auto& c : cart_bindings) {
+        const int slot = c.value("slot", -1);
+        const std::string uuid = c.value("itemUuid", std::string{});
+        if (slot < 0 || uuid.empty()) continue;
+        json entry{{"slot", slot}, {"itemUuid", uuid}};
+        if (auto it = facts.find(uuid); it != facts.end()) entry["name"] = it->second.name;
+        entry["playing"] = std::any_of(on_air.begin(), on_air.end(),
+                                       [&](const OnAir& e){ return e.uuid == uuid; });
+        cart.push_back(std::move(entry));
+    }
+
+    return json{
+        {"project", std::move(project_block)},
+        {"playing", std::move(playing)},
+        {"next",    std::move(next)},
+        {"master", json{
+            {"gainDb",         engine_.master_gain_db()},
+            {"limiterEnabled", engine_.limiter_enabled()},
+        }},
+        {"cart",    std::move(cart)},
+        {"preview", json{
+            {"active",   !current_preview_item_uuid().empty()},
+            {"itemUuid", current_preview_item_uuid()},
+        }},
+    };
+}
+
+std::string ProjectState::go() {
+    std::string target;
+    {
+        std::lock_guard lock{mutex_};
+        target = next_item_override_;
+    }
+    const bool from_override = !target.empty();
+
+    if (target.empty()) {
+        // No override armed — derive from the currently-playing item's
+        // endBehavior, the same fallback the client's GO button uses.
+        std::vector<std::pair<std::string, audio::CueId>> pairs;
+        {
+            std::lock_guard lock{mutex_};
+            pairs.reserve(item_uuid_to_cue_.size());
+            for (const auto& [u, c] : item_uuid_to_cue_) pairs.emplace_back(u, c);
+        }
+        std::vector<std::string> on_air;
+        for (const auto& [u, c] : pairs) {
+            if (auto* pi = engine_.find_cue(c)) {
+                if (pi->stats().transport != audio::TransportState::Stopped)
+                    on_air.push_back(u);
+            }
+        }
+        {
+            std::lock_guard lock{mutex_};
+            for (const auto& u : on_air) {
+                const auto n = resolve_next_item_locked(u);
+                if (!n.empty()) { target = n; break; }
+            }
+        }
+    }
+
+    if (target.empty()) return {};
+    if (!trigger_item(target)) return {};
+    // Consume the override only after a successful trigger so a GO against a
+    // not-yet-loaded item doesn't silently disarm the operator's choice.
+    if (from_override) set_next_item_override("");
+    return target;
+}
+
+std::string ProjectState::cart_slot_item_uuid(int slot) const {
+    std::lock_guard lock{mutex_};
+    if (!document_.contains("cartItems") || !document_["cartItems"].is_array())
+        return {};
+    for (const auto& c : document_["cartItems"]) {
+        if (c.is_object() && c.value("slot", -1) == slot)
+            return c.value("itemUuid", std::string{});
+    }
+    return {};
+}
+
 // Dispatch by item type: audio → play_item; group → walk startBehavior
 // (play-first plays the first child recursively; play-all triggers every
 // child). Mirrors the client's triggerGroup() so auto-next / Up Next

--- a/server/src/core/project_state.cpp
+++ b/server/src/core/project_state.cpp
@@ -23,6 +23,20 @@ inline std::string id_to_string(const audio::CueId& id)          { return id.val
 inline std::string id_to_string(const audio::MixerChannelId& id) { return id.value; }
 inline std::string id_to_string(const audio::DeviceId& id)       { return id.value; }
 
+// Type-safe JSON field read. Unlike nlohmann's .value<T>()/.at().get<T>(),
+// this never throws on a wrong-typed (or null) field — it returns `def`
+// instead. Malformed project fields (e.g. a number where a string is
+// expected) would otherwise throw nlohmann::type_error uncaught through the
+// network layer. (#5)
+template <class T>
+T json_get_or(const nlohmann::json& j, const char* key, const T& def) noexcept {
+    try {
+        if (auto it = j.find(key); it != j.end() && !it->is_null())
+            return it->get<T>();
+    } catch (...) {}
+    return def;
+}
+
 // Convert a Unix timestamp (seconds since epoch) to an ISO 8601 UTC string.
 inline std::string unix_ts_to_iso(std::int64_t unix_sec) {
     const std::time_t t = static_cast<std::time_t>(unix_sec);
@@ -1389,12 +1403,6 @@ bool ProjectState::save(const std::filesystem::path& path) const {
     // engine state) live on the side and don't get written to disk here;
     // they're rebuilt from the document on next load.
     try {
-        std::ofstream f{path};
-        if (!f) {
-            Logger::error("ProjectState::save: cannot open '{}' for writing",
-                          util::path_to_utf8(path));
-            return false;
-        }
         json doc;
         {
             std::lock_guard lock{mutex_};
@@ -1405,7 +1413,44 @@ bool ProjectState::save(const std::filesystem::path& path) const {
         // folder, so the saved file stays portable across moves. Covers items
         // imported this session (which carry an absolute mediaServerPath).
         relativize_media_paths(doc);
-        f << doc.dump(2);
+
+        // Atomic write: serialise to a sibling temp file, verify the stream is
+        // healthy, then rename it over the target. A write error, disk-full, or
+        // crash therefore never truncates or corrupts the previous good file —
+        // the documented "preserve previous state on failure" contract. (#5)
+        std::filesystem::path tmp = path;
+        tmp += ".tmp";
+        {
+            std::ofstream f{tmp, std::ios::binary | std::ios::trunc};
+            if (!f) {
+                Logger::error("ProjectState::save: cannot open '{}' for writing",
+                              util::path_to_utf8(tmp));
+                return false;
+            }
+            f << doc.dump(2);
+            f.flush();
+            f.close();
+            if (!f.good()) {
+                Logger::error("ProjectState::save: failed writing '{}' — "
+                              "previous file left untouched",
+                              util::path_to_utf8(tmp));
+                std::error_code rm_ec;
+                std::filesystem::remove(tmp, rm_ec);
+                return false;
+            }
+        }
+
+        std::error_code ec;
+        std::filesystem::rename(tmp, path, ec);
+        if (ec) {
+            Logger::error("ProjectState::save: rename '{}' -> '{}' failed: {} — "
+                          "previous file left untouched",
+                          util::path_to_utf8(tmp), util::path_to_utf8(path),
+                          ec.message());
+            std::error_code rm_ec;
+            std::filesystem::remove(tmp, rm_ec);
+            return false;
+        }
         return true;
     } catch (const std::exception& ex) {
         Logger::error("ProjectState::save failed: {}", ex.what());
@@ -1773,16 +1818,16 @@ bool ProjectState::update_item(const std::string& uuid, const json& patch) {
                 have_seq_cue  = true;
                 seq_cue       = cit->second;
                 const json& it = *updated_item;
-                seq_in_point  = it.value("inPoint",  0.0);
-                seq_out_point = it.value("outPoint", 0.0);
-                seq_crossfade = it.value("crossFade", 0.0);
-                seq_stop_fade = it.value("stopFade",  0.0);
-                seq_sn_enabled   = it.value("startNextEnabled", false);
-                seq_sn_time      = it.value("startNextTime",    0.0);
-                seq_sn_fade_out  = it.value("startNextFadeOut", false);
-                seq_fade_out_dur = it.value("fadeOutDuration",  1.0);
+                seq_in_point  = json_get_or(it, "inPoint",  0.0);
+                seq_out_point = json_get_or(it, "outPoint", 0.0);
+                seq_crossfade = json_get_or(it, "crossFade", 0.0);
+                seq_stop_fade = json_get_or(it, "stopFade",  0.0);
+                seq_sn_enabled   = json_get_or(it, "startNextEnabled", false);
+                seq_sn_time      = json_get_or(it, "startNextTime",    0.0);
+                seq_sn_fade_out  = json_get_or(it, "startNextFadeOut", false);
+                seq_fade_out_dur = json_get_or(it, "fadeOutDuration",  1.0);
                 if (it.contains("endBehavior") && it["endBehavior"].is_object())
-                    seq_end_action = it["endBehavior"].value("action", std::string{});
+                    seq_end_action = json_get_or(it["endBehavior"], "action", std::string{});
                 auto cm_it = cues_.find(cit->second.value);
                 if (cm_it != cues_.end())
                     seq_file_duration = cm_it->second.duration_seconds;
@@ -2071,6 +2116,9 @@ std::string ProjectState::item_uuid_by_index(const std::vector<int>& path) const
 bool ProjectState::play_item(const std::string& uuid,
                              double fade_in_override_sec,
                              const audio::CueId& exclude_from_ducking) {
+  // Guard the whole body: a malformed item field must never throw uncaught
+  // into the network layer. (#5)
+  try {
     // Snapshot everything we need under the lock, then release before
     // touching the engine (engine calls take their own locks).
     std::string  ducking_mode  = "stop-all";
@@ -2117,14 +2165,14 @@ bool ProjectState::play_item(const std::string& uuid,
         if (!found && doc.contains("cartOnlyItems")) walk(doc["cartOnlyItems"]);
 
         if (found) {
-            in_point      = found->value("inPoint",         0.0);
-            out_point     = found->value("outPoint",         0.0);
-            fade_out_dur  = found->value("fadeOutDuration",  1.0);
-            crossfade_sec = found->value("crossFade",        0.0);
-            stop_fade_sec = found->value("stopFade",         0.0);
-            start_next_enabled  = found->value("startNextEnabled",  false);
-            start_next_time     = found->value("startNextTime",     0.0);
-            start_next_fade_out = found->value("startNextFadeOut",  false);
+            in_point      = json_get_or(*found, "inPoint",         0.0);
+            out_point     = json_get_or(*found, "outPoint",         0.0);
+            fade_out_dur  = json_get_or(*found, "fadeOutDuration",  1.0);
+            crossfade_sec = json_get_or(*found, "crossFade",        0.0);
+            stop_fade_sec = json_get_or(*found, "stopFade",         0.0);
+            start_next_enabled  = json_get_or(*found, "startNextEnabled",  false);
+            start_next_time     = json_get_or(*found, "startNextTime",     0.0);
+            start_next_fade_out = json_get_or(*found, "startNextFadeOut",  false);
             if (found->contains("duckingBehavior") &&
                 (*found)["duckingBehavior"].is_object()) {
                 const auto& dk = (*found)["duckingBehavior"];
@@ -2351,6 +2399,10 @@ bool ProjectState::play_item(const std::string& uuid,
     }
 
     return true;
+  } catch (const std::exception& e) {
+    Logger::error("ProjectState::play_item('{}') failed: {}", uuid, e.what());
+    return false;
+  }
 }
 
 bool ProjectState::stop_item(const std::string& uuid) {
@@ -2693,6 +2745,9 @@ std::string ProjectState::cart_slot_item_uuid(int slot) const {
 bool ProjectState::trigger_item(const std::string& uuid,
                                 double fade_in_override_sec,
                                 const audio::CueId& exclude_from_ducking) {
+  // Guard the whole body: a malformed item field must never throw uncaught
+  // into the network layer. (#5)
+  try {
     // Look up the item's type and (for groups) startBehavior + children.
     std::string type;
     std::string start_action;
@@ -2752,6 +2807,10 @@ bool ProjectState::trigger_item(const std::string& uuid,
         return trigger_item(child_uuids.front(), fade_in_override_sec, exclude_from_ducking);
     }
     return false;
+  } catch (const std::exception& e) {
+    Logger::error("ProjectState::trigger_item('{}') failed: {}", uuid, e.what());
+    return false;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -2781,6 +2840,26 @@ ProjectState::ensure_device_routing(const std::string& device_name) {
     audio::MasterChannelIndex master_r;
     {
         std::lock_guard lock{mutex_};
+        // Bound-check master allocation. Each distinct device override consumes
+        // a pair of master channels growing upward from next_override_master_,
+        // while the top two channels of the bus are reserved for preview
+        // (kPreviewMasterL/R). Never allocate into or past that reserve — doing
+        // so would collide with preview output or run past the engine's master
+        // bus width. Compute the reserved base from the live bus width rather
+        // than trusting the 30/31 literals. (#5)
+        const audio::MasterChannelIndex bus_width =
+            engine_.config().master_channels;
+        const audio::MasterChannelIndex reserved_base =
+            (bus_width >= 2) ? static_cast<audio::MasterChannelIndex>(bus_width - 2)
+                             : 0;
+        if (next_override_master_ + 1 >= reserved_base) {
+            Logger::error(
+                "ensure_device_routing: out of master channels for '{}' "
+                "(next={}, reserved_base={}, bus_width={}); item will use "
+                "default routing instead of a dedicated device master",
+                device_name, next_override_master_, reserved_base, bus_width);
+            return {};
+        }
         master_l = next_override_master_;
         master_r = next_override_master_ + 1;
         next_override_master_ += 2;
@@ -3419,13 +3498,18 @@ void ProjectState::apply_to_engine_locked() {
     for (auto& [_, c] : cues_) {
         const auto id = engine_.load_cue(c.file_path, c.id);
         if (!id.empty()) {
-            engine_.find_cue(id)->set_gain_db(c.gain_db);
-            engine_.find_cue(id)->set_fade_in (c.fade_in_ms);
-            engine_.find_cue(id)->set_fade_out(c.fade_out_ms);
+            // Cache the lookup once and null-check it — find_cue can return
+            // null (e.g. the load raced with an unload) and the previous code
+            // dereferenced it up to six times unchecked. (#5)
+            auto* cue = engine_.find_cue(id);
+            if (!cue) continue;
+            cue->set_gain_db(c.gain_db);
+            cue->set_fade_in (c.fade_in_ms);
+            cue->set_fade_out(c.fade_out_ms);
             if (c.ltc_enabled) {
-                engine_.find_cue(id)->set_ltc_enabled(true);
-                engine_.find_cue(id)->set_ltc_frame_rate(fps_index_to_rate(c.ltc_frame_rate_index));
-                engine_.find_cue(id)->set_ltc_offset(c.ltc_offset_ns);
+                cue->set_ltc_enabled(true);
+                cue->set_ltc_frame_rate(fps_index_to_rate(c.ltc_frame_rate_index));
+                cue->set_ltc_offset(c.ltc_offset_ns);
             }
         }
     }
@@ -3935,7 +4019,8 @@ void ProjectState::arm_next_after_stop(const std::string& stopped_uuid,
         // is auto-advanced by the sequencer itself.
         std::string action = "nothing";
         if (found->contains("endBehavior") && (*found)["endBehavior"].is_object())
-            action = (*found)["endBehavior"].value("action", std::string{"nothing"});
+            action = json_get_or((*found)["endBehavior"], "action",
+                                 std::string{"nothing"});
         if (action != "nothing") return;
 
         // Advance to the next sibling in document order.

--- a/server/src/crash_handler.cpp
+++ b/server/src/crash_handler.cpp
@@ -1,9 +1,27 @@
 // ============================================================================
 // crash_handler.cpp — see crash_handler.hpp.
+// ----------------------------------------------------------------------------
+// Two crash-emit paths:
+//   * emit_crash_report()      — rich report (session history, symbolised
+//                                stack). Used from contexts where it is safe to
+//                                allocate / lock / touch the filesystem:
+//                                Windows SEH + CRT handlers, and std::terminate.
+//   * async_signal_crash()     — POSIX-only, async-signal-SAFE path used from
+//                                the fatal-signal handler (SIGSEGV/ABRT/…). Uses
+//                                only write()/open()/backtrace_symbols_fd()/fork/
+//                                execve, never malloc / mutex / iostream, so it
+//                                can't deadlock on a crash that happened while
+//                                the faulting thread held the malloc arena lock.
+//
+// Both paths share a persisted consecutive-crash counter so a deterministic
+// crash can't relaunch the server forever (crash-loop protection), and both
+// read crash-resume state from a lock-free double buffer that is never observed
+// half-written.
 // ============================================================================
 #include "liveplay/crash_handler.hpp"
 #include "liveplay/logger.hpp"
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <csignal>
@@ -32,6 +50,8 @@
 #    include <execinfo.h>
 #    define LIVEPLAY_HAVE_EXECINFO 1
 #  endif
+#  include <cerrno>
+#  include <fcntl.h>
 #  include <unistd.h>
 #  include <sys/types.h>
 #  include <sys/wait.h>
@@ -52,17 +72,43 @@ constexpr std::size_t kPathBuf = 4096;
 constexpr std::size_t kArgBuf  = 8192;
 constexpr std::size_t kUuidBuf = 256;
 
-char g_exe_path[kPathBuf]           = {};
-char g_restart_args[kArgBuf]        = {};
-char g_project_dir[kPathBuf]        = {};
-char g_resume_project_file[kPathBuf]= {};
-char g_resume_item_uuid[kUuidBuf]   = {};
-// Plain double is fine here; worst case: a torn read gives a slightly wrong
-// seek position — acceptable in a crash-resume scenario.
-double g_resume_position_sec        = 0.0;
+char g_exe_path[kPathBuf]     = {};
+char g_restart_args[kArgBuf]  = {};
+char g_project_dir[kPathBuf]  = {};
+
+// Pre-resolved + pre-created crash-log directory. Refreshed in safe context
+// (install / set_crash_project_dir) so the signal handler never has to call
+// create_directories(). Empty until first refresh.
+char g_crash_log_dir_buf[kPathBuf] = {};
+
+// ---- Crash-loop protection -------------------------------------------------
+char             g_counter_file[kPathBuf] = {};
+std::atomic<int> g_crash_count{0};       // consecutive crashes so far
+std::atomic<int> g_max_consecutive{0};   // 0 = guard disabled (always restart)
+
+// ---- Crash-resume state (lock-free double buffer) --------------------------
+// The writer fills the inactive buffer completely, then atomically flips the
+// active index. A reader (the crash handler) only ever reads the active index,
+// which always points at a fully-written record — even if the crashing thread
+// was interrupted mid-write, it was writing the *inactive* buffer.
+struct ResumeState {
+    char   project_file[kPathBuf] = {};
+    char   item_uuid[kUuidBuf]    = {};
+    double position_sec           = 0.0;
+};
+ResumeState      g_resume[2];
+std::atomic<int> g_resume_active{-1};   // -1 = no record yet
+
+long long current_pid() {
+#if defined(_WIN32)
+    return static_cast<long long>(GetCurrentProcessId());
+#else
+    return static_cast<long long>(::getpid());
+#endif
+}
 
 // ---------------------------------------------------------------------------
-// Helpers
+// Helpers (safe context)
 // ---------------------------------------------------------------------------
 std::string timestamp_for_filename() {
     using clock = std::chrono::system_clock;
@@ -74,20 +120,21 @@ std::string timestamp_for_filename() {
     localtime_r(&now, &tm);
 #endif
     char buf[32];
-    // Format: YYYY_MM_DD-HHMM  (as requested)
-    std::snprintf(buf, sizeof(buf), "%04d_%02d_%02d-%02d%02d",
+    // Seconds resolution + PID keep filenames unique across a fast crash loop
+    // (minute resolution + O_TRUNC used to overwrite prior logs).
+    std::snprintf(buf, sizeof(buf), "%04d_%02d_%02d-%02d%02d%02d",
                   tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
-                  tm.tm_hour, tm.tm_min);
+                  tm.tm_hour, tm.tm_min, tm.tm_sec);
     return std::string{buf};
 }
 
-std::filesystem::path resolve_crash_log_path() {
+// Recompute + create the crash-log directory into g_crash_log_dir_buf. Safe
+// context only (allocates / touches the filesystem).
+void refresh_log_dir() {
     namespace fs = std::filesystem;
     std::error_code ec;
-
     fs::path dir;
     if (g_project_dir[0] != '\0') {
-        // Preferred: <project_dir>/logs/
         dir = fs::path{g_project_dir} / "logs";
     } else if (!g_crash_log_dir.empty()) {
         dir = g_crash_log_dir;
@@ -96,7 +143,18 @@ std::filesystem::path resolve_crash_log_path() {
         if (ec) dir = ".";
     }
     fs::create_directories(dir, ec);
-    return dir / ("liveplay-crash-" + timestamp_for_filename() + ".log");
+    const std::string s = dir.string();
+    std::strncpy(g_crash_log_dir_buf, s.c_str(), kPathBuf - 1);
+    g_crash_log_dir_buf[kPathBuf - 1] = '\0';
+}
+
+std::filesystem::path resolve_crash_log_path() {
+    namespace fs = std::filesystem;
+    fs::path dir = g_crash_log_dir_buf[0] ? fs::path{g_crash_log_dir_buf} : fs::path{"."};
+    std::error_code ec;
+    fs::create_directories(dir, ec);
+    return dir / ("liveplay-crash-" + timestamp_for_filename() + "-" +
+                  std::to_string(current_pid()) + ".log");
 }
 
 // Minimal JSON string escaper — safe to call from the crash handler.
@@ -112,6 +170,19 @@ std::string json_escape(const char* s) {
         }
     }
     return out;
+}
+
+// Increment the persisted consecutive-crash counter and report whether the
+// server should still auto-restart. Safe context (uses ofstream).
+bool bump_counter_and_should_restart() {
+    const int new_count = g_crash_count.load(std::memory_order_acquire) + 1;
+    g_crash_count.store(new_count, std::memory_order_release);
+    if (g_counter_file[0] != '\0') {
+        std::ofstream cf{g_counter_file, std::ios::binary | std::ios::trunc};
+        if (cf) cf << new_count;
+    }
+    const int maxc = g_max_consecutive.load(std::memory_order_acquire);
+    return !(maxc > 0 && new_count > maxc);
 }
 
 // ---------------------------------------------------------------------------
@@ -216,14 +287,19 @@ std::string format_stack_trace_posix() {
 #endif
 
 // ---------------------------------------------------------------------------
-// Core: write crash log + console output + restart after 5 s.
+// Rich crash report — SAFE contexts only (Windows SEH/CRT, std::terminate).
 // ---------------------------------------------------------------------------
 void emit_crash_report(const std::string& reason, const std::string& trace) {
+    const bool will_restart = bump_counter_and_should_restart();
+
     // 1. Console output — visible to the operator while the window is up.
     try {
         Logger::error("==================== SERVER CRASH ====================");
         Logger::error("Reason : {}", reason);
-        Logger::error("Restart: server will relaunch in 5 seconds.");
+        if (will_restart)
+            Logger::error("Restart: server will relaunch in 5 seconds.");
+        else
+            Logger::error("Restart: DISABLED — too many consecutive crashes; not relaunching.");
         Logger::error("Log    : see liveplay-crash-*.log in the project /logs/ folder.");
         Logger::error("Stack trace:");
         std::istringstream is{trace};
@@ -242,6 +318,7 @@ void emit_crash_report(const std::string& reason, const std::string& trace) {
             f << "LivePlay Server — Crash Report\n"
               << "================================\n"
               << "Time   : " << timestamp_for_filename() << "\n"
+              << "PID    : " << current_pid() << "\n"
               << "Reason : " << reason << "\n\n"
               << "Stack trace:\n" << trace << "\n"
               << "================================\n"
@@ -254,30 +331,30 @@ void emit_crash_report(const std::string& reason, const std::string& trace) {
 
     // 3. Persist resume state so the new instance can reopen the project and
     //    resume playback from approximately where it stopped.
-    if (g_exe_path[0] != '\0' && g_resume_project_file[0] != '\0') {
+    const int ri = g_resume_active.load(std::memory_order_acquire);
+    if (g_exe_path[0] != '\0' && ri >= 0 && g_resume[ri].project_file[0] != '\0') {
         try {
             namespace fs = std::filesystem;
-
-            // Store next to the exe so the new instance finds it at startup.
             const fs::path resume_path =
                 fs::path{g_exe_path}.parent_path() / ".crash-resume.json";
             std::ofstream rf{resume_path, std::ios::binary | std::ios::trunc};
             if (rf) {
                 char pos_buf[64];
-                std::snprintf(pos_buf, sizeof(pos_buf), "%.3f", g_resume_position_sec);
+                std::snprintf(pos_buf, sizeof(pos_buf), "%.3f", g_resume[ri].position_sec);
                 rf << "{\n"
-                   << "  \"projectFile\": \""  << json_escape(g_resume_project_file) << "\",\n"
-                   << "  \"itemUuid\": \""      << json_escape(g_resume_item_uuid)    << "\",\n"
-                   << "  \"positionSec\": "     << pos_buf                            << "\n"
+                   << "  \"projectFile\": \""  << json_escape(g_resume[ri].project_file) << "\",\n"
+                   << "  \"itemUuid\": \""      << json_escape(g_resume[ri].item_uuid)    << "\",\n"
+                   << "  \"positionSec\": "     << pos_buf                                << "\n"
                    << "}\n";
             }
         } catch (...) {}
     }
 
+    if (!will_restart) return;
+
     // 4. Relaunch the server, then exit so the OS releases our listening port.
-    //    Rather than sleeping here (which would hold the port for 5 s and race
-    //    the new instance for it), we spawn immediately and pass --start-delay-ms
-    //    so the *new* instance waits before binding — by which point we're gone.
+    //    We spawn immediately and pass --start-delay-ms so the *new* instance
+    //    waits before binding — by which point we're gone.
 #if defined(_WIN32)
     if (g_exe_path[0] != '\0') {
         std::string cmd = std::string{"\""} + g_exe_path + "\"";
@@ -297,14 +374,11 @@ void emit_crash_report(const std::string& reason, const std::string& trace) {
         if (pi.hThread)  CloseHandle(pi.hThread);
     }
 #else
-    // Fork a child that sleeps then execs the server; the crashing parent exits.
     if (g_exe_path[0] != '\0') {
         const pid_t pid = ::fork();
         if (pid == 0) {
-            // Child: sleep 5 s then exec the original binary.
             ::sleep(5);
             if (g_restart_args[0] != '\0') {
-                // Use sh to re-parse the arg string.
                 std::string cmd = std::string{g_exe_path} + " " + g_restart_args;
                 ::execl("/bin/sh", "sh", "-c", cmd.c_str(), nullptr);
             } else {
@@ -312,10 +386,163 @@ void emit_crash_report(const std::string& reason, const std::string& trace) {
             }
             ::_exit(1);
         }
-        // Parent falls through and exits normally below.
     }
 #endif
 }
+
+// ---------------------------------------------------------------------------
+// Async-signal-safe crash emit — POSIX fatal-signal path ONLY.
+// ---------------------------------------------------------------------------
+#if !defined(_WIN32)
+// Small async-signal-safe output primitives (no malloc / stdio / locale).
+struct AsBuf { char* p; std::size_t cap; std::size_t len; };
+
+void as_append(AsBuf& b, const char* s) {
+    while (*s && b.len + 1 < b.cap) b.p[b.len++] = *s++;
+    b.p[b.len] = '\0';
+}
+void as_append_ll(AsBuf& b, long long v) {
+    char t[32]; int i = static_cast<int>(sizeof(t));
+    const bool neg = v < 0;
+    unsigned long long u = neg ? (0ULL - static_cast<unsigned long long>(v))
+                               : static_cast<unsigned long long>(v);
+    if (u == 0) t[--i] = '0';
+    while (u) { t[--i] = static_cast<char>('0' + u % 10); u /= 10; }
+    if (neg) t[--i] = '-';
+    for (; i < static_cast<int>(sizeof(t)) && b.len + 1 < b.cap; ++i) b.p[b.len++] = t[i];
+    b.p[b.len] = '\0';
+}
+void as_write(int fd, const char* s, std::size_t n) {
+    while (n > 0) {
+        const ssize_t w = ::write(fd, s, n);
+        if (w <= 0) { if (errno == EINTR) continue; break; }
+        s += w; n -= static_cast<std::size_t>(w);
+    }
+}
+void as_write_str(int fd, const char* s) {
+    std::size_t n = 0; while (s[n]) ++n; as_write(fd, s, n);
+}
+void as_write_ll(int fd, long long v) {
+    char t[32]; AsBuf b{t, sizeof(t), 0}; t[0] = '\0';
+    as_append_ll(b, v); as_write(fd, t, b.len);
+}
+void as_write_escaped(int fd, const char* s) {
+    for (; *s; ++s) {
+        switch (*s) {
+            case '"':  as_write(fd, "\\\"", 2); break;
+            case '\\': as_write(fd, "\\\\", 2); break;
+            case '\n': as_write(fd, "\\n", 2);  break;
+            case '\r': as_write(fd, "\\r", 2);  break;
+            default:   as_write(fd, s, 1);      break;
+        }
+    }
+}
+void as_write_fixed3(int fd, double v) {
+    bool neg = v < 0; if (neg) v = -v;
+    long long whole = static_cast<long long>(v);
+    long long frac  = static_cast<long long>((v - static_cast<double>(whole)) * 1000.0 + 0.5);
+    if (frac >= 1000) { whole += 1; frac -= 1000; }
+    if (neg) as_write(fd, "-", 1);
+    as_write_ll(fd, whole);
+    as_write(fd, ".", 1);
+    char f[3] = { static_cast<char>('0' + (frac / 100) % 10),
+                  static_cast<char>('0' + (frac / 10) % 10),
+                  static_cast<char>('0' + frac % 10) };
+    as_write(fd, f, 3);
+}
+
+void async_signal_crash(const char* reason) {
+    const long long epoch = static_cast<long long>(::time(nullptr));
+    const long long pid   = static_cast<long long>(::getpid());
+
+    // Build "<dir>/liveplay-crash-<epoch>-<pid>.log" without allocating.
+    char path[kPathBuf]; AsBuf pb{path, sizeof(path), 0}; path[0] = '\0';
+    if (g_crash_log_dir_buf[0]) { as_append(pb, g_crash_log_dir_buf); as_append(pb, "/"); }
+    as_append(pb, "liveplay-crash-");
+    as_append_ll(pb, epoch); as_append(pb, "-"); as_append_ll(pb, pid);
+    as_append(pb, ".log");
+
+    const int fd = ::open(path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd >= 0) {
+        as_write_str(fd, "LivePlay Server — Crash Report\n"
+                         "================================\n"
+                         "Time (epoch): ");
+        as_write_ll(fd, epoch);
+        as_write_str(fd, "\nPID    : "); as_write_ll(fd, pid);
+        as_write_str(fd, "\nReason : "); as_write_str(fd, reason);
+        as_write_str(fd, "\n\nStack trace:\n");
+#if defined(LIVEPLAY_HAVE_EXECINFO)
+        void* bt[64];
+        const int n = backtrace(bt, 64);
+        backtrace_symbols_fd(bt, n, fd);   // async-signal-safe (no malloc)
+#else
+        as_write_str(fd, "(stack trace unavailable: execinfo.h not present)\n");
+#endif
+        as_write_str(fd, "\n(session history is in the rolling server log, if enabled)\n");
+        ::close(fd);
+    }
+
+    // Visible operator signal on stderr.
+    as_write_str(STDERR_FILENO, "\n==================== SERVER CRASH ====================\n");
+    as_write_str(STDERR_FILENO, reason);
+    as_write_str(STDERR_FILENO, "\nCrash log: "); as_write_str(STDERR_FILENO, path);
+    as_write_str(STDERR_FILENO, "\n");
+
+    // Persist crash-resume state from the double buffer (always complete).
+    const int ri = g_resume_active.load(std::memory_order_acquire);
+    if (g_exe_path[0] && ri >= 0 && g_resume[ri].project_file[0]) {
+        char rpath[kPathBuf]; AsBuf rb{rpath, sizeof(rpath), 0}; rpath[0] = '\0';
+        as_append(rb, g_exe_path);
+        // Trim to the executable's parent directory.
+        std::size_t cut = rb.len;
+        while (cut > 0 && rpath[cut - 1] != '/') --cut;
+        rb.len = cut; rpath[rb.len] = '\0';
+        as_append(rb, ".crash-resume.json");
+        const int rfd = ::open(rpath, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+        if (rfd >= 0) {
+            as_write_str(rfd, "{\n  \"projectFile\": \"");
+            as_write_escaped(rfd, g_resume[ri].project_file);
+            as_write_str(rfd, "\",\n  \"itemUuid\": \"");
+            as_write_escaped(rfd, g_resume[ri].item_uuid);
+            as_write_str(rfd, "\",\n  \"positionSec\": ");
+            as_write_fixed3(rfd, g_resume[ri].position_sec);
+            as_write_str(rfd, "\n}\n");
+            ::close(rfd);
+        }
+    }
+
+    // Crash-loop guard: persist the incremented counter and decide.
+    const int new_count = g_crash_count.load(std::memory_order_acquire) + 1;
+    if (g_counter_file[0]) {
+        const int cfd = ::open(g_counter_file, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+        if (cfd >= 0) { as_write_ll(cfd, new_count); ::close(cfd); }
+    }
+    const int maxc = g_max_consecutive.load(std::memory_order_acquire);
+    if (maxc > 0 && new_count > maxc) {
+        as_write_str(STDERR_FILENO,
+                     "Auto-restart DISABLED — too many consecutive crashes.\n");
+        return;
+    }
+
+    // Relaunch: fork a child that waits then re-execs; the parent returns and
+    // the caller re-raises the signal so the OS frees our listening port.
+    if (g_exe_path[0]) {
+        const pid_t child = ::fork();
+        if (child == 0) {
+            ::sleep(5);
+            if (g_restart_args[0]) {
+                char cmd[kArgBuf + kPathBuf + 8];
+                AsBuf cb{cmd, sizeof(cmd), 0}; cmd[0] = '\0';
+                as_append(cb, g_exe_path); as_append(cb, " "); as_append(cb, g_restart_args);
+                ::execl("/bin/sh", "sh", "-c", cmd, static_cast<char*>(nullptr));
+            } else {
+                ::execl(g_exe_path, g_exe_path, static_cast<char*>(nullptr));
+            }
+            ::_exit(127);
+        }
+    }
+}
+#endif // !_WIN32
 
 // ---------------------------------------------------------------------------
 // Platform handlers
@@ -404,7 +631,8 @@ extern "C" void posix_fatal_signal(int sig) {
 #  endif
         default: break;
     }
-    emit_crash_report(name, format_stack_trace_posix());
+    // Async-signal-safe path: no malloc / mutex / iostream / filesystem.
+    async_signal_crash(name);
     std::signal(sig, SIG_DFL);
     std::raise(sig);
 }
@@ -418,6 +646,7 @@ extern "C" void posix_fatal_signal(int sig) {
 void install_crash_handlers(const std::string& log_dir) {
     std::call_once(g_install_flag, [&]{
         g_crash_log_dir = log_dir;
+        refresh_log_dir();
 
         std::set_terminate(&terminate_handler);
 
@@ -456,14 +685,68 @@ void set_crash_exe_info(const std::string& exe_path,
 
 void set_crash_project_dir(const std::string& project_dir) {
     std::strncpy(g_project_dir, project_dir.c_str(), kPathBuf - 1);
+    g_project_dir[kPathBuf - 1] = '\0';
+    refresh_log_dir();
 }
 
 void update_crash_resume_state(const std::string& project_file,
                                 const std::string& playing_item_uuid,
                                 double             position_sec) {
-    std::strncpy(g_resume_project_file, project_file.c_str(),        kPathBuf - 1);
-    std::strncpy(g_resume_item_uuid,    playing_item_uuid.c_str(),   kUuidBuf - 1);
-    g_resume_position_sec = position_sec;
+    // Fill the inactive buffer, then publish it by flipping the active index.
+    const int active = g_resume_active.load(std::memory_order_acquire);
+    const int next   = (active == 0) ? 1 : 0;   // -1 or 1 → 0; 0 → 1
+    ResumeState& b = g_resume[next];
+    std::strncpy(b.project_file, project_file.c_str(),      kPathBuf - 1);
+    b.project_file[kPathBuf - 1] = '\0';
+    std::strncpy(b.item_uuid,    playing_item_uuid.c_str(), kUuidBuf - 1);
+    b.item_uuid[kUuidBuf - 1] = '\0';
+    b.position_sec = position_sec;
+    g_resume_active.store(next, std::memory_order_release);
+}
+
+void set_crash_restart_guard(const std::string& counter_file,
+                             int consecutive_so_far,
+                             int max_consecutive) {
+    std::strncpy(g_counter_file, counter_file.c_str(), kPathBuf - 1);
+    g_counter_file[kPathBuf - 1] = '\0';
+    g_crash_count.store(consecutive_so_far < 0 ? 0 : consecutive_so_far,
+                        std::memory_order_release);
+    g_max_consecutive.store(max_consecutive, std::memory_order_release);
+}
+
+void reset_crash_restart_guard() {
+    g_crash_count.store(0, std::memory_order_release);
+    if (g_counter_file[0] != '\0') {
+        std::ofstream cf{g_counter_file, std::ios::binary | std::ios::trunc};
+        if (cf) cf << 0;
+    }
+}
+
+void prune_crash_logs(const std::string& dir, std::size_t keep) {
+    namespace fs = std::filesystem;
+    try {
+        std::error_code ec;
+        if (!fs::is_directory(dir, ec)) return;
+        std::vector<fs::path> logs;
+        for (const auto& entry : fs::directory_iterator(dir, ec)) {
+            if (ec) break;
+            const auto& p = entry.path();
+            const std::string fn = p.filename().string();
+            if (fn.rfind("liveplay-crash-", 0) == 0 && p.extension() == ".log")
+                logs.push_back(p);
+        }
+        if (logs.size() <= keep) return;
+        std::sort(logs.begin(), logs.end(), [](const fs::path& a, const fs::path& b) {
+            std::error_code e1, e2;
+            return fs::last_write_time(a, e1) < fs::last_write_time(b, e2);
+        });
+        for (std::size_t i = 0; i + keep < logs.size(); ++i) {
+            std::error_code rec;
+            fs::remove(logs[i], rec);
+        }
+    } catch (...) {
+        // Best-effort pruning — never let it affect startup.
+    }
 }
 
 } // namespace liveplay

--- a/server/src/logger.cpp
+++ b/server/src/logger.cpp
@@ -7,6 +7,8 @@
 #include <chrono>
 #include <cstdio>
 #include <ctime>
+#include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <mutex>
 #include <string>
@@ -55,6 +57,13 @@ struct RingBuffer {
 RingBuffer& ring_buffer() {
     static RingBuffer rb;
     return rb;
+}
+
+// Optional persistent log file. Guarded by Logger::mutex() (same lock that
+// serialises console writes and the ring buffer).
+std::ofstream& log_file() {
+    static std::ofstream f;
+    return f;
 }
 
 LoggerState& state() {
@@ -181,6 +190,34 @@ void Logger::set_min_level(LogLevel level) {
     state().min_level.store(level);
 }
 
+void Logger::set_log_file(const std::string& path, std::size_t max_bytes) {
+    std::lock_guard lock{mutex()};
+    auto& lf = log_file();
+    if (lf.is_open()) lf.close();
+    if (path.empty()) return;
+
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    const fs::path p{path};
+    if (p.has_parent_path()) fs::create_directories(p.parent_path(), ec);
+
+    // Single-generation size rotation: if the current file is already large,
+    // move it aside before reopening so the active log doesn't grow unbounded.
+    const auto sz = fs::file_size(p, ec);
+    if (!ec && sz >= max_bytes) {
+        fs::path rotated = p;
+        rotated += ".1";
+        fs::remove(rotated, ec);
+        fs::rename(p, rotated, ec);
+    }
+
+    lf.open(path, std::ios::binary | std::ios::app);
+    if (!lf) {
+        // Never throw from logging setup; console logging still works.
+        std::cerr << "[logger] failed to open log file: " << path << '\n';
+    }
+}
+
 bool Logger::color_enabled() {
     return state().color_enabled.load();
 }
@@ -201,6 +238,10 @@ void Logger::log(LogLevel level, std::string_view msg) {
 
     std::lock_guard lock{mutex()};
     ring_buffer().push(plain_line);
+    if (auto& lf = log_file(); lf.is_open()) {
+        lf << plain_line << '\n';
+        lf.flush();
+    }
     if (colored) {
         stream << style.color << ansi::dim << '[' << ts << ']' << ansi::reset << ' '
                << style.color << ansi::bold << '[' << style.tag << ']' << ansi::reset << ' '

--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -459,6 +459,34 @@ int main(int argc, char** argv) {
     install_crash_handlers((exe_dir / "crash-logs").string());
     set_crash_exe_info(exe_path_str, restart_args);
 
+    // Mirror the session to a persistent, size-rotated log file so operators
+    // have history even when stdout isn't captured (server launched by the
+    // Electron client). Best-effort; console logging is unaffected on failure.
+    Logger::set_log_file((exe_dir / "logs" / "liveplay-server.log").string());
+
+    // Crash-loop protection. Read the persisted consecutive-crash count left by
+    // any crashing predecessor; after kMaxConsecutiveCrashes back-to-back
+    // crashes the handler stops auto-restarting so a deterministic fault (e.g. a
+    // bad crash-resume project) can't relaunch forever. The count is reset once
+    // this instance has run healthily (see the heartbeat loop) or shuts cleanly.
+    constexpr int kMaxConsecutiveCrashes = 5;
+    constexpr int kCrashGuardHealthySec  = 30;
+    int prior_crash_count = 0;
+    {
+        std::ifstream cf{(exe_dir / ".crash-count").string()};
+        int v = 0;
+        if (cf && (cf >> v) && v > 0) prior_crash_count = v;
+    }
+    set_crash_restart_guard((exe_dir / ".crash-count").string(),
+                            prior_crash_count, kMaxConsecutiveCrashes);
+    if (prior_crash_count > 0) {
+        Logger::warn("Recovered from a crash ({} consecutive). Auto-restart disables after {}.",
+                     prior_crash_count, kMaxConsecutiveCrashes);
+    }
+    // Keep only the most recent crash logs in the fallback dir (project /logs/
+    // crash logs are pruned by the project itself).
+    prune_crash_logs((exe_dir / "crash-logs").string(), 20);
+
     // ------------------------------------------------------------------
     // Check for a crash-resume file left by a previous crashed instance.
     // ------------------------------------------------------------------
@@ -686,11 +714,23 @@ int main(int argc, char** argv) {
     // Heartbeat loop. Every 30 s we tick a debug line so operators can confirm
     // the process is alive over long sessions. SIGINT/SIGTERM flips g_running.
     using clock = std::chrono::steady_clock;
+    const auto program_start = clock::now();
+    bool crash_guard_reset   = false;
     auto last_heartbeat   = clock::now();
     auto last_resume_snap = clock::now();
     while (g_running.load()) {
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
         const auto now = clock::now();
+
+        // Once we've been up long enough to be considered "healthy", clear the
+        // consecutive-crash counter so isolated crashes over a long session
+        // don't accumulate toward the auto-restart give-up threshold.
+        if (!crash_guard_reset &&
+            std::chrono::duration_cast<std::chrono::seconds>(now - program_start).count()
+                >= kCrashGuardHealthySec) {
+            reset_crash_restart_guard();
+            crash_guard_reset = true;
+        }
 
         // ---- crash-resume: play item once audio has fully loaded ------------
         if (pending_resume) {
@@ -745,6 +785,9 @@ int main(int argc, char** argv) {
 
     Logger::raw("");
     Logger::info("Shutdown signal received — stopping cleanly.");
+    // A clean exit is not a crash — clear the consecutive-crash counter so the
+    // next launch starts fresh.
+    reset_crash_restart_guard();
     if (beacon) beacon->stop();
     beacon.reset();
     server->stop();

--- a/server/src/meta/metadata.cpp
+++ b/server/src/meta/metadata.cpp
@@ -92,6 +92,15 @@ AudioFileMetadata read_metadata(const std::filesystem::path& path) noexcept {
         out.duration = duration_via_miniaudio(path);
         out.valid    = out.duration.count() > 0;
         return out;
+    } catch (...) {
+        // read_metadata is declared noexcept; a non-std throw from TagLib on a
+        // corrupt file must not escape and terminate the process (e.g. during a
+        // bulk library scan). Degrade to the miniaudio fallback for this file.
+        Logger::error("read_metadata unknown (non-std) exception for '{}'", utf8);
+        out.title    = util::path_to_utf8(path.stem());
+        out.duration = duration_via_miniaudio(path);
+        out.valid    = out.duration.count() > 0;
+        return out;
     }
 }
 

--- a/server/src/net/control_server.cpp
+++ b/server/src/net/control_server.cpp
@@ -847,6 +847,17 @@ static std::string handle_ws_message(crow::websocket::connection& conn,
                              fade ? std::to_string(*fade) + "ms" : "project default");
             state.stop_all_cues(fade);
         }
+        else if (type == "go") {
+            // Play whatever is armed as "Up Next" (override first, else the
+            // playing item's endBehavior target). Same semantics as
+            // POST /api/transport/go.
+            const auto uuid = state.go();
+            if (uuid.empty()) {
+                Logger::warn("WS go: nothing armed or derivable to play");
+                return json({{"type", "error"}, {"message", "nothing armed to GO to"}}).dump();
+            }
+            Logger::playback("GO: {}", item_playback_info(uuid, state));
+        }
         else if (type == "gain") {
             auto cue = resolve_cue(j);
             if (cue) {
@@ -1106,6 +1117,87 @@ void ControlServer::install_routes() {
             } catch (const std::exception& e) { return json_err(400, e.what()); }
         });
 
+    // ---- External-control surface (Bitfocus Companion, custom remotes) ----
+    // Compact machine-readable transport summary. Control surfaces fetch this
+    // once on connect (and after a project_changed doc_patch), then keep it
+    // fresh from the /ws push stream — no polling.
+    CROW_ROUTE(app, "/api/state/summary").methods(crow::HTTPMethod::Get)
+        ([this] {
+            try {
+                json s = state_.state_summary();
+                s["server"] = json{
+                    {"version", std::string{
+#ifdef LIVEPLAY_SERVER_VERSION
+                        LIVEPLAY_SERVER_VERSION
+#else
+                        "0.0.0"
+#endif
+                    }},
+                    {"meterBroadcastHz", cfg_.meter_broadcast_hz},
+                };
+                return json_ok(s);
+            } catch (const std::exception& e) { return json_err(500, e.what()); }
+            catch (...) { return json_err(500, "internal error"); }
+        });
+
+    // GO — play whatever is armed as "Up Next" (user override first, else the
+    // playing item's endBehavior target). GET is accepted as well as POST so
+    // the URL can be fired from a browser or a plain `curl`.
+    CROW_ROUTE(app, "/api/transport/go")
+        .methods(crow::HTTPMethod::Post, crow::HTTPMethod::Get)
+        ([this](const crow::request& req){
+            Logger::api_request("Client ({}) -> Server ({}) : {} /api/transport/go",
+                                req.remote_ip_address, impl_->server_addr,
+                                crow::method_name(req.method));
+            const std::string uuid = state_.go();
+            if (uuid.empty()) {
+                Logger::warn("GO — nothing armed or derivable to play");
+                return json_err(404, "nothing armed or playing to GO to");
+            }
+            Logger::playback("GO: {}", item_playback_info(uuid, state_));
+            return json_ok(json({{"ok", true}, {"uuid", uuid}}));
+        });
+
+    // First-class body-addressed variant of /api/project/items/by-index/…
+    // Body: { "index": [1, 11] } — an index path descending into groups.
+    CROW_ROUTE(app, "/api/transport/play_index").methods(crow::HTTPMethod::Post)
+        ([this](const crow::request& req){
+            try {
+                auto j = json::parse(req.body);
+                std::vector<int> path;
+                if (j.contains("index") && j["index"].is_array()) {
+                    for (const auto& v : j["index"]) {
+                        if (!v.is_number_integer() || v.get<int>() < 0)
+                            return json_err(400, "index must contain non-negative integers");
+                        path.push_back(v.get<int>());
+                    }
+                }
+                if (path.empty())
+                    return json_err(400, "index must be a non-empty array of child indices");
+                const std::string uuid = state_.item_uuid_by_index(path);
+                if (uuid.empty()) return json_err(404, "no item at that index");
+                Logger::playback("TRIGGER: {}", item_playback_info(uuid, state_));
+                if (!state_.trigger_item(uuid))
+                    return json_err(404, "item not loaded into engine");
+                return json_ok(json({{"ok", true}, {"uuid", uuid}, {"index", path}}));
+            } catch (const std::exception& e) { return json_err(400, e.what()); }
+        });
+
+    // Trigger the item bound to a cart slot. GET accepted for curl/browser.
+    CROW_ROUTE(app, "/api/transport/cart/<int>/play")
+        .methods(crow::HTTPMethod::Post, crow::HTTPMethod::Get)
+        ([this](const crow::request& req, int slot){
+            Logger::api_request("Client ({}) -> Server ({}) : {} /api/transport/cart/{}/play",
+                                req.remote_ip_address, impl_->server_addr,
+                                crow::method_name(req.method), slot);
+            const std::string uuid = state_.cart_slot_item_uuid(slot);
+            if (uuid.empty()) return json_err(404, "cart slot is empty");
+            Logger::playback("CART {}: {}", slot, item_playback_info(uuid, state_));
+            if (!state_.trigger_item(uuid))
+                return json_err(404, "item not loaded into engine");
+            return json_ok(json({{"ok", true}, {"slot", slot}, {"uuid", uuid}}));
+        });
+
     CROW_ROUTE(app, "/api/master/ceiling").methods(crow::HTTPMethod::Post)
         ([this](const crow::request& req){
             try {
@@ -1121,13 +1213,41 @@ void ControlServer::install_routes() {
         ([this](const crow::request& req){
             try {
                 auto j = json::parse(req.body);
-                const float db = j.value("db", 0.0f);
+                // "db" sets an absolute gain; "delta" nudges the current gain
+                // (control-surface increment/decrement without a read-modify-
+                // write race on the caller's side). "db" wins if both present.
+                float db;
+                if (!j.contains("db") && j.contains("delta") && j["delta"].is_number())
+                    db = engine_.master_gain_db() + j["delta"].get<float>();
+                else
+                    db = j.value("db", 0.0f);
                 engine_.set_master_gain_db(db);
                 broadcast_doc_patch(json{
                     {"type", "doc_patch"}, {"op", "master_gain_changed"},
                     {"db", engine_.master_gain_db()},
                 });
                 return json_ok(json({{"ok", true}, {"db", engine_.master_gain_db()}}));
+            } catch (const std::exception& e) { return json_err(400, e.what()); }
+        });
+
+    // Master brickwall limiter enable/bypass. POST body { "enabled": bool };
+    // omitting "enabled" toggles the current state (single-button surfaces).
+    CROW_ROUTE(app, "/api/master/limiter").methods(crow::HTTPMethod::Get)
+        ([this]{ return json_ok(json({{"enabled", engine_.limiter_enabled()}})); });
+    CROW_ROUTE(app, "/api/master/limiter").methods(crow::HTTPMethod::Post)
+        ([this](const crow::request& req){
+            try {
+                auto j = json::parse(req.body.empty() ? std::string{"{}"} : req.body);
+                const bool enabled =
+                    (j.contains("enabled") && j["enabled"].is_boolean())
+                        ? j["enabled"].get<bool>()
+                        : !engine_.limiter_enabled();
+                engine_.set_limiter_enabled(enabled);
+                broadcast_doc_patch(json{
+                    {"type", "doc_patch"}, {"op", "limiter_changed"},
+                    {"enabled", enabled},
+                });
+                return json_ok(json({{"ok", true}, {"enabled", enabled}}));
             } catch (const std::exception& e) { return json_err(400, e.what()); }
         });
 
@@ -2327,6 +2447,34 @@ void ControlServer::install_routes() {
             Logger::api_response("Client ({}) <- Server ({}) : POST /api/project/items/{}/stop OK",
                                  req.remote_ip_address, impl_->server_addr, uuid);
             return json_ok(json({{"ok", true}}));
+        });
+    // Pause / resume hold the playhead without unloading. REST mirror of the
+    // WS "pause"/"resume" messages so stateless control surfaces can use them.
+    CROW_ROUTE(app, "/api/project/items/<string>/pause").methods(crow::HTTPMethod::Post)
+        ([this](const crow::request& req, std::string uuid){
+            Logger::api_request("Client ({}) -> Server ({}) : POST /api/project/items/{}/pause",
+                                req.remote_ip_address, impl_->server_addr, uuid);
+            const auto cue = state_.item_to_cue_id(uuid);
+            if (!cue) return json_err(404, "item not loaded into engine");
+            if (auto* pi = engine_.find_cue(*cue)) {
+                Logger::playback("PAUSE: {}", item_playback_info(uuid, state_));
+                pi->pause();
+                return json_ok(json({{"ok", true}}));
+            }
+            return json_err(404, "item not loaded into engine");
+        });
+    CROW_ROUTE(app, "/api/project/items/<string>/resume").methods(crow::HTTPMethod::Post)
+        ([this](const crow::request& req, std::string uuid){
+            Logger::api_request("Client ({}) -> Server ({}) : POST /api/project/items/{}/resume",
+                                req.remote_ip_address, impl_->server_addr, uuid);
+            const auto cue = state_.item_to_cue_id(uuid);
+            if (!cue) return json_err(404, "item not loaded into engine");
+            if (auto* pi = engine_.find_cue(*cue)) {
+                Logger::playback("RESUME: {}", item_playback_info(uuid, state_));
+                pi->resume();
+                return json_ok(json({{"ok", true}}));
+            }
+            return json_err(404, "item not loaded into engine");
         });
     CROW_ROUTE(app, "/api/project/items/<string>/seek").methods(crow::HTTPMethod::Post)
         ([this](const crow::request& req, std::string uuid){

--- a/server/src/net/control_server.cpp
+++ b/server/src/net/control_server.cpp
@@ -277,11 +277,19 @@ static void register_download_token(const std::string& token, fs::path path) {
 
 static std::optional<fs::path> redeem_download_token(const std::string& token) {
     std::lock_guard lock{g_download_tokens_mutex};
-    // GC any expired entries while we're here.
+    // GC any expired entries while we're here. An expired-and-unclaimed token
+    // still has its .lpa sitting on disk (redeem is the only path that deletes
+    // it), so remove the file before dropping the entry — otherwise abandoned
+    // exports leak temp files indefinitely.
     const auto now = std::chrono::steady_clock::now();
     for (auto it = g_download_tokens.begin(); it != g_download_tokens.end();) {
-        if (it->second.expires_at <= now) it = g_download_tokens.erase(it);
-        else ++it;
+        if (it->second.expires_at <= now) {
+            std::error_code ec;
+            fs::remove(it->second.path, ec);
+            it = g_download_tokens.erase(it);
+        } else {
+            ++it;
+        }
     }
     auto it = g_download_tokens.find(token);
     if (it == g_download_tokens.end()) return std::nullopt;
@@ -831,9 +839,15 @@ static std::string handle_ws_message(crow::websocket::connection& conn,
                                      cue->value);
                     if (type == "pause") pi->pause();
                     else                 pi->resume();
+                } else {
+                    Logger::warn("WS {}: cue_id={} not live in engine", type, cue->value);
+                    return json({{"type", "error"},
+                                 {"message", type + ": cue not loaded into engine"}}).dump();
                 }
             } else {
                 Logger::warn("WS {}: no valid cue target", type);
+                return json({{"type", "error"},
+                             {"message", type + ": no valid cue target"}}).dump();
             }
         }
         else if (type == "stop_all") {
@@ -885,7 +899,15 @@ static std::string handle_ws_message(crow::websocket::connection& conn,
                 Logger::playback("SEEK {:.2f}s → cue_id={}", secs, cue->value);
                 if (auto* pi = engine.find_cue(*cue)) {
                     pi->seek_seconds(secs);
+                } else {
+                    Logger::warn("WS seek: cue_id={} not live in engine", cue->value);
+                    return json({{"type", "error"},
+                                 {"message", "seek: cue not loaded into engine"}}).dump();
                 }
+            } else {
+                Logger::warn("WS seek: no valid cue target");
+                return json({{"type", "error"},
+                             {"message", "seek: no valid cue target"}}).dump();
             }
         }
         else if (type == "set_next_item") {
@@ -931,6 +953,25 @@ void ControlServer::install_routes() {
     static CrowLogBridge crow_log_bridge;
     crow::logger::setHandler(&crow_log_bridge);
     crow::logger::setLogLevel(crow::LogLevel::Warning);
+
+    // Central exception handler: any route that throws past its own try/catch
+    // (or has none) lands here instead of Crow's bare 500. Crow invokes this
+    // from inside a catch(...) block, so a `throw;` re-raises the active
+    // exception, letting us recover its message. We reply with the same JSON +
+    // CORS shape as json_err() so browser clients never see an opaque,
+    // CORS-less 500.
+    app.exception_handler([](crow::response& res){
+        std::string message = "internal server error";
+        try {
+            throw;
+        } catch (const std::exception& e) {
+            message = e.what();
+            Logger::error("Uncaught exception in route handler: {}", e.what());
+        } catch (...) {
+            Logger::error("Uncaught non-std exception in route handler.");
+        }
+        res = json_err(500, message);
+    });
 
     // Permissive CORS preflight for everything (the Electron client is on a
     // different origin).
@@ -1033,17 +1074,22 @@ void ControlServer::install_routes() {
 
     CROW_ROUTE(app, "/api/cues/<string>").methods(crow::HTTPMethod::Delete)
         ([this](std::string id) {
+            // remove_cue() returns void, so probe existence first and 404 if
+            // the target cue is unknown (mirrors the item play/stop routes).
+            if (!state_.find_cue(audio::CueId{id})) return json_err(404, "not found");
             state_.remove_cue(audio::CueId{id});
             return json_ok(json({{"ok", true}}));
         });
 
     CROW_ROUTE(app, "/api/cues/<string>/play").methods(crow::HTTPMethod::Post)
         ([this](std::string id) {
+            if (!engine_.find_cue(audio::CueId{id})) return json_err(404, "not found");
             engine_.play(audio::CueId{id});
             return json_ok(json({{"ok", true}}));
         });
     CROW_ROUTE(app, "/api/cues/<string>/stop").methods(crow::HTTPMethod::Post)
         ([this](std::string id) {
+            if (!engine_.find_cue(audio::CueId{id})) return json_err(404, "not found");
             engine_.stop(audio::CueId{id});
             return json_ok(json({{"ok", true}}));
         });
@@ -1307,6 +1353,9 @@ void ControlServer::install_routes() {
 
     CROW_ROUTE(app, "/api/mixers/<string>").methods(crow::HTTPMethod::Delete)
         ([this](std::string id){
+            // remove_mixer_channel() returns void; probe first and 404 if absent.
+            if (!engine_.find_mixer_channel(audio::MixerChannelId{id}))
+                return json_err(404, "not found");
             engine_.remove_mixer_channel(audio::MixerChannelId{id});
             return json_ok(json({{"ok", true}}));
         });
@@ -2016,27 +2065,36 @@ void ControlServer::install_routes() {
     // a temp dir server-side.
     CROW_ROUTE(app, "/api/file/download").methods(crow::HTTPMethod::Get)
         ([this](const crow::request& req){
-            const char* token = req.url_params.get("token");
-            if (!token) return json_err(400, "missing ?token=");
-            auto path_opt = redeem_download_token(token);
-            if (!path_opt) return json_err(404, "token expired or invalid");
-            const fs::path& p = *path_opt;
-            std::ifstream f{p, std::ios::binary | std::ios::ate};
-            if (!f) return json_err(500, "failed to open archive");
-            const auto size = f.tellg();
-            f.seekg(0, std::ios::beg);
-            std::string body(static_cast<std::size_t>(size), '\0');
-            f.read(body.data(), size);
+            try {
+                const char* token = req.url_params.get("token");
+                if (!token) return json_err(400, "missing ?token=");
+                auto path_opt = redeem_download_token(token);
+                if (!path_opt) return json_err(404, "token expired or invalid");
+                const fs::path& p = *path_opt;
+                std::ifstream f{p, std::ios::binary | std::ios::ate};
+                if (!f) return json_err(500, "failed to open archive");
+                const auto size = f.tellg();
+                f.seekg(0, std::ios::beg);
+                std::string body(static_cast<std::size_t>(size), '\0');
+                f.read(body.data(), size);
 
-            crow::response r{200, std::move(body)};
-            r.add_header("Content-Type", "application/octet-stream");
-            r.add_header("Content-Disposition",
-                         "attachment; filename=\"" + p.filename().string() + "\"");
-            r.add_header("Access-Control-Allow-Origin", "*");
-            // The temp file has served its purpose; delete it to bound disk
-            // usage on the server.
-            std::error_code ec; fs::remove(p, ec);
-            return r;
+                crow::response r{200, std::move(body)};
+                r.add_header("Content-Type", "application/octet-stream");
+                // Encode the filename via path_to_utf8 rather than the native
+                // .string() (which decodes through the active code page and can
+                // throw on non-representable Unicode names).
+                r.add_header("Content-Disposition",
+                             "attachment; filename=\""
+                                 + liveplay::util::path_to_utf8(p.filename()) + "\"");
+                r.add_header("Access-Control-Allow-Origin", "*");
+                // The temp file has served its purpose; delete it to bound disk
+                // usage on the server.
+                std::error_code ec; fs::remove(p, ec);
+                return r;
+            } catch (const std::exception& e) {
+                Logger::error("GET /api/file/download threw: {}", e.what());
+                return json_err(400, e.what());
+            }
         });
 
     // Import a .lpa archive that the client uploaded via multipart, OR an
@@ -2529,7 +2587,11 @@ void ControlServer::install_routes() {
         ([this](const crow::request& req, int slot){
             Logger::api_request("Client ({}) -> Server ({}) : DELETE /api/project/cart/{}",
                                 req.remote_ip_address, impl_->server_addr, slot);
-            state_.clear_cart_slot(slot);
+            // clear_cart_slot() returns false when the slot held no binding.
+            if (!state_.clear_cart_slot(slot)) {
+                Logger::warn("DELETE /api/project/cart/{} — no binding at slot", slot);
+                return json_err(404, "no binding at slot");
+            }
             Logger::api_response("Client ({}) <- Server ({}) : DELETE /api/project/cart/{} OK",
                                  req.remote_ip_address, impl_->server_addr, slot);
             broadcast_doc_patch(json{

--- a/server/src/net/control_server.cpp
+++ b/server/src/net/control_server.cpp
@@ -416,6 +416,11 @@ void ControlServer::broadcast_loop() {
     auto next_tick = clock::now() + period;
 
     while (running_.load(std::memory_order_acquire)) {
+        // Guard the entire tick: an exception escaping this thread would call
+        // std::terminate() and take the whole audio process down mid-show.
+        // Log-and-continue instead so a transient fault (e.g. a flaky media
+        // share throwing out of a filesystem call) just drops one meter frame.
+        try {
 
         // Build the meters payload.
         json payload;
@@ -572,6 +577,16 @@ void ControlServer::broadcast_loop() {
         std::this_thread::sleep_until(next_tick);
         next_tick += period;
         if (next_tick < clock::now()) next_tick = clock::now() + period;
+
+        } catch (const std::exception& e) {
+            Logger::error("broadcast_loop: unhandled exception (continuing): {}", e.what());
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+            next_tick = clock::now() + period;
+        } catch (...) {
+            Logger::error("broadcast_loop: unknown exception (continuing).");
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+            next_tick = clock::now() + period;
+        }
     }
 }
 
@@ -611,18 +626,23 @@ void ControlServer::waveform_worker() {
             impl_->waveform_q.pop_front();
         }
 
+        // Guard the whole task: an exception here (e.g. the throwing fs::exists
+        // overload faulting on a disconnected network share, or compute_waveform
+        // throwing) would escape this thread and std::terminate() the process.
+        try {
+
+        std::error_code fs_ec;
         const fs::path json_file = task.waveforms_dir.empty()
             ? fs::path{}
             : task.waveforms_dir / (task.item_uuid + ".json");
 
         // Remove stale cache entry when a forced regeneration is requested.
-        if (task.force && !json_file.empty() && fs::exists(json_file)) {
-            std::error_code ec;
-            fs::remove(json_file, ec);
+        if (task.force && !json_file.empty() && fs::exists(json_file, fs_ec)) {
+            fs::remove(json_file, fs_ec);
         }
 
         // Serve from disk cache when available (skips full audio decode).
-        if (!json_file.empty() && fs::exists(json_file)) {
+        if (!json_file.empty() && fs::exists(json_file, fs_ec)) {
             try {
                 std::ifstream cache_f(json_file);
                 const auto cached = json::parse(cache_f);
@@ -692,6 +712,12 @@ void ControlServer::waveform_worker() {
 
         broadcast_doc_patch(std::move(patch));
         Logger::info("waveform_worker: done for item_uuid '{}'", task.item_uuid);
+
+        } catch (const std::exception& e) {
+            Logger::error("waveform_worker: unhandled exception (skipping task): {}", e.what());
+        } catch (...) {
+            Logger::error("waveform_worker: unknown exception (skipping task).");
+        }
     }
 }
 


### PR DESCRIPTION
**This PR incorporates 4 independent fixes. All are server-side (C++ audio engine); no client or protocol-breaking changes.**

These fixes all are intended to increase the robustness of the audio engine which, in its current state, is a bit fragile.

### 1. Playback transport/fade/seek correctness & data races (playback_item)

- Re-trigger no longer dips to silence. play() on a cue that's mid stop-fade now fades in from the current gain instead of hardcoded 0; a Paused cue routes to resume() rather than restarting the fade envelope.
- Seek past end no longer desyncs the playhead. seek_seconds() checks the decoder seek result and resyncs the playhead from the decoder cursor when a seek past a VBR file's true end fails, and stores the playhead inside the decoder lock (no torn read vs. the audio thread).
- Removed data races: fade-in/out durations and decoder_ready_ are now atomics (audio thread reads them without racing control-thread writes); the three meter setters take decoder_mutex_ so a concurrent reload/LTC toggle can't reallocate source_meters_ mid-iteration.
- load() now stops playback before swapping the decoder; set_loop() clamps a loop-in point at/beyond the out-point to avoid a rapid retrigger loop.

### 2. ProjectState durability & robustness (project_state)

- Atomic save: the project file is written to a temp sibling, verified good(), then renamed over the target. A write error, disk-full, or crash can no longer truncate the previous good file.
- Malformed-document safety: a json_get_or<T>() helper replaces throwing field reads at the transport hot-paths, and play_item()/trigger_item() bodies are wrapped so a wrong-typed field in a project file can't throw uncaught into the network layer.
- Master-channel bound check prevents per-device-override routing from colliding with the reserved preview channels or overrunning the bus.
- Cached null-check in apply_to_engine_locked()

### 3. REST/WebSocket API error handling & consistency (control_server)

- 404 instead of false success on DELETE /api/cues/{id}, POST /api/cues/{id}/play|stop, DELETE /api/mixers/{id}, and DELETE /api/project/cart/{n} when the target doesn't exist.
- Central Crow exception handler returns a JSON body + CORS header on any uncaught route exception, instead of Crow's bare, CORS-less 500.
- WebSocket pause/resume/seek now send an error frame when the cue isn't live in the engine, rather than silently no-op'ing.
- Expired-and-unclaimed download tokens delete their temp .lpa (no more leaked exports); the download Content-Disposition uses UTF-8 filename encoding and is wrapped in try/catch.

### 4. Render-thread & DSP robustness (engine, limiter, metadata, playback_item)

- FTZ/DAZ enabled on the render thread (x86) so denormal meter/limiter states during silence can't cause CPU spikes.
- Interleaved decode buffer moved off the audio thread's first-block allocation.
- Limiter::process() hard-clips to 0 dBFS when unconfigured instead of passing audio through untouched. 
- read_metadata() catches non-std exceptions so a corrupt file can't violate its noexcept contract and terminate a bulk scan.
- Added a had_decode_error() flag set on unexpected mid-playback decoder errors (no logging on the audio path).