### PR TITLE
fix: three project-sync bugs found while building cue-to-continue

### DIFF
--- a/client/app/composables/useProject.ts
+++ b/client/app/composables/useProject.ts
@@ -54,6 +54,10 @@ import {
 let _syncWatchersInstalled = false;
 let _refreshItemsBaselineAfterHydrate: () => void = () => {};
 let _captureBaselinesFn: () => void = () => {};
+// Bridges endItemBatch (outer composable scope) to syncItemsDiff (defined
+// inside the one-time sync-watcher init block) — see endItemBatch's comment
+// for why calling this directly, not just captureBaselines, matters.
+let _syncItemsDiffFn: () => Promise<void> = async () => {};
 let _installItemsWatcherFn:   null | (() => void) = null;
 let _uninstallItemsWatcherFn: null | (() => void) = null;
 
@@ -1549,9 +1553,22 @@ export const useProject = () => {
                 cacheWaveform(patch.item_uuid, (target as any).waveform);
 
                 if (!hadWaveform && duration > 0) {
-                  // First waveform for this item: initialise duration + out point.
+                  // First waveform for this item this session: initialise duration.
                   (target as any).duration = duration;
-                  (target as any).outPoint  = duration;
+                  // Only initialise outPoint for a genuinely brand-new item.
+                  // `_waveformCache` is in-memory only and starts empty on every
+                  // reload, so `!hadWaveform` is ALSO true for an existing,
+                  // already-trimmed item whose waveform just happens to be the
+                  // first this fresh session has seen — without this check that
+                  // reload would stomp its real, already-hydrated outPoint back
+                  // to full duration the instant the waveform arrives (in-point
+                  // is never touched here, which is why only out-points were
+                  // reverting). The item's own outPoint — hydrated from the
+                  // project file before this patch ever arrives — is the
+                  // persistent signal the session cache can't provide.
+                  if (!(target as any).outPoint) {
+                    (target as any).outPoint = duration;
+                  }
                 }
 
                 // Auto-process (trim silence + normalise) only for items that
@@ -1792,12 +1809,29 @@ export const useProject = () => {
       }
 
       // 4. Updates: items whose content changed (not cross-parent, not new).
+      //
+      // A group's own JSON embeds its full `children` array, so ANY child
+      // property edit (e.g. a trim point) also changes the group's serialized
+      // JSON — which would otherwise queue a *second*, redundant PATCH for the
+      // group here, carrying a full snapshot of every child. The server's
+      // update_item does a blind per-key merge (`it[k] = v`), so if that
+      // group-level patch is built from a snapshot older than the child's own
+      // more specific patch and lands after it (a real race under rapid edits
+      // or concurrent activity — overlapping syncItemsDiff calls don't
+      // serialize against each other), it silently reverts the child back to
+      // the stale value embedded in the group's snapshot. Children are already
+      // synced via their own uuid entries in this same loop — a group patch
+      // should only ever carry the group's own metadata, never children.
+      const withoutChildren = (it: any) =>
+        it && it.type === 'group' ? { ...it, children: undefined } : it;
       for (const [uuid, { item, parentUuid, cartOnly }] of curr) {
         const before = prev.get(uuid);
         if (!before) continue;
         if (before.parentUuid !== parentUuid || before.cartOnly !== cartOnly) continue; // handled in step 1
-        if (stableJson(before.item) === stableJson(item)) continue;
-        try { await srv.updateProjectItem(uuid, item); } catch {}
+        const beforeCompare = withoutChildren(before.item);
+        const nowCompare    = withoutChildren(item);
+        if (stableJson(beforeCompare) === stableJson(nowCompare)) continue;
+        try { await srv.updateProjectItem(uuid, nowCompare); } catch {}
       }
 
       // 5. Reorder: for each parent level, if the item order changed call
@@ -1833,6 +1867,7 @@ export const useProject = () => {
         }
       }
     }
+    _syncItemsDiffFn = syncItemsDiff;
 
     // ---- Fallback for keys without granular endpoints ----
     // Only fires when one of the specific "no-endpoint-yet" fields changes
@@ -1885,7 +1920,20 @@ export const useProject = () => {
   // Drag-batch helpers — defined at composable scope so they're always
   // accessible from the return object regardless of the init-block latch.
   const beginItemBatch = () => { _suppressItemSyncCount.value++; };
-  const endItemBatch   = () => { _suppressItemSyncCount.value = 0; _captureBaselinesFn(); };
+  // Bug fix: this used to call only _captureBaselinesFn(), which re-snapshots
+  // the *current* (just-dragged, never-sent) item state as the new baseline —
+  // marking the drag's final value as "already in sync" without ever pushing
+  // it to the server. The change looked fine locally but the server (and the
+  // saved project file) kept the pre-drag value, so it silently reverted on
+  // the next reload. _syncItemsDiffFn() (syncItemsDiff) is what actually
+  // diffs against the old baseline and pushes the change before rotating it —
+  // call that first, then _captureBaselinesFn() as a safety net for the
+  // non-item fields (cart/theme/settings) it also baselines.
+  const endItemBatch = () => {
+    _suppressItemSyncCount.value = 0;
+    _syncItemsDiffFn().catch(e => console.warn('[useProject] endItemBatch sync failed:', e));
+    _captureBaselinesFn();
+  };
 
   return {
     currentProject,

--- a/client/package.json
+++ b/client/package.json
@@ -38,6 +38,7 @@
     "typescript": "^5.3.3",
     "vue": "^3.5.13",
     "vue-router": "^4.5.0",
+    "vue-tsc": "^3.3.8",
     "wait-on": "^7.2.0"
   },
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "liveplay-monorepo",
-  "version": "2.3.0",
+  "version": "2.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "liveplay-monorepo",
-      "version": "2.3.0",
+      "version": "2.4.2",
       "license": "AGPL-3.0-only",
       "workspaces": [
         "client"
@@ -22,7 +22,7 @@
     },
     "client": {
       "name": "liveplay",
-      "version": "2.3.0",
+      "version": "2.4.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
@@ -49,6 +49,7 @@
         "typescript": "^5.3.3",
         "vue": "^3.5.13",
         "vue-router": "^4.5.0",
+        "vue-tsc": "^3.3.8",
         "wait-on": "^7.2.0"
       }
     },
@@ -2103,8 +2104,10 @@
       "version": "13.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
       "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2627,9 +2630,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2647,9 +2647,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2667,9 +2664,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2687,9 +2681,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2707,9 +2698,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2727,9 +2715,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2747,9 +2732,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2767,9 +2749,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2992,9 +2971,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3012,9 +2988,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3032,9 +3005,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3052,9 +3022,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3072,9 +3039,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3092,9 +3056,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3112,9 +3073,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3132,9 +3090,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3367,9 +3322,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3387,9 +3339,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3407,9 +3356,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3427,9 +3373,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3447,9 +3390,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3467,9 +3407,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3487,9 +3424,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3507,9 +3441,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3734,9 +3665,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3758,9 +3686,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3782,9 +3707,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3806,9 +3728,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3830,9 +3749,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3854,9 +3770,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4170,9 +4083,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4191,9 +4101,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4212,9 +4119,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4233,9 +4137,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4254,9 +4155,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4275,9 +4173,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4680,9 +4575,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4697,9 +4589,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4714,9 +4603,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4731,9 +4617,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4748,9 +4631,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4765,9 +4645,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4782,9 +4659,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4799,9 +4673,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4816,9 +4687,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4833,9 +4701,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4850,9 +4715,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4867,9 +4729,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4884,9 +4743,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5317,6 +5173,35 @@
         "vue": "^3.0.0"
       }
     },
+    "node_modules/@volar/language-core": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+      "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.28"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@volar/typescript": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+      "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
     "node_modules/@vue-macros/common": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@vue-macros/common/-/common-3.1.2.tgz",
@@ -5510,6 +5395,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@vue/language-core": {
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.8.tgz",
+      "integrity": "sha512-ieGT8jJdhhy0mGzStZhsg/qPw5bQZJg5yF+3+XU6saf4sM7yo9ZXy3h+nCwrm2+b4qS/SypkNdR2jAF3uei9tA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "@vue/compiler-dom": "^3.5.0",
+        "@vue/shared": "^3.5.0",
+        "alien-signals": "^3.2.1",
+        "muggle-string": "^0.4.1",
+        "path-browserify": "^1.0.1",
+        "picomatch": "^4.0.4"
+      }
+    },
     "node_modules/@vue/reactivity": {
       "version": "3.5.39",
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.39.tgz",
@@ -5659,6 +5560,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/alien-signals": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.2.1.tgz",
+      "integrity": "sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -10043,9 +9951,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10068,9 +9973,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10093,9 +9995,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10118,9 +10017,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11716,6 +11612,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
@@ -15261,6 +15164,13 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vue": {
       "version": "3.5.39",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.39.tgz",
@@ -15314,6 +15224,23 @@
       },
       "peerDependencies": {
         "vue": "^3.5.0"
+      }
+    },
+    "node_modules/vue-tsc": {
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.8.tgz",
+      "integrity": "sha512-xXmYlVQpcwJDWyGlqbHrGVOl1h3UOsASymRibrHc+iy9j/UNnOrOn4u+fntHz4D6Cs74RtapeqVV6CzJeg+UlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/typescript": "2.4.28",
+        "@vue/language-core": "3.3.8"
+      },
+      "bin": {
+        "vue-tsc": "bin/vue-tsc.js"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
       }
     },
     "node_modules/wait-on": {


### PR DESCRIPTION
Closes #48, closes #49, closes #50.

While building a new playback feature (see the follow-up PR) I hit three separate, pre-existing project-sync bugs — all in `client/app/composables/useProject.ts`, all unrelated to that feature, so splitting them out here.

## #48 — group item PATCH echoes a stale children snapshot
A group's serialized JSON embeds its full `children` array, so any child property edit (e.g. a trim point) also makes the *parent group's* JSON look changed to the item-diff watcher — queuing a second, redundant PATCH for the group carrying a full snapshot of every child. The server's `update_item` does a blind per-key merge, so a stale group-level snapshot landing after a child's own more specific PATCH silently reverts it. Fix: strip `children` from a group's own diff comparison and PATCH payload — children already sync via their own per-uuid diff entries in the same pass.

## #49 — waveform_ready resets outPoint to full duration on reload
The "is this a brand-new item?" check for whether to default `outPoint = duration` used an in-memory-only cache that's wiped by every reload — so an existing, already-trimmed item gets its out point reset the instant its waveform arrives post-reload. `inPoint` is never touched by this path, which is why only end markers were reverting. Fix: also check the item's own already-hydrated `outPoint` before defaulting it.

## #50 — endItemBatch drops the final value of a batched drag
`endItemBatch` re-baselined the diff watcher's comparison state without ever flushing the pending diff first, so a drag-batched edit (trim points, volume, fades) looked correct locally but was never actually sent to the server. Fix: flush the diff before re-baselining.

## Testing
Reproduced and verified each fix directly against the server's REST API (not just the UI) — confirmed values persist through a full app restart, not just a page reload, and confirmed the child-value race by deliberately firing rapid concurrent edits.